### PR TITLE
Add insights.ubuntu.com

### DIFF
--- a/ingresses/production/insights.ubuntu.com.yaml
+++ b/ingresses/production/insights.ubuntu.com.yaml
@@ -1,0 +1,24 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: insights-ubuntu-com
+  namespace: production
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  tls:
+  - secretName: insights-ubuntu-com-tls
+    hosts:
+    - insights.ubuntu.com
+  rules:
+  - host: insights.ubuntu.com
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: insights-ubuntu-com
+          servicePort: 80
+
+---

--- a/ingresses/staging/insights.staging.ubuntu.com.yaml
+++ b/ingresses/staging/insights.staging.ubuntu.com.yaml
@@ -3,7 +3,7 @@
 kind: Ingress
 apiVersion: extensions/v1beta1
 metadata:
-  name: staging-insights-ubuntu-com
+  name: insights-staging-ubuntu-com
   namespace: staging
   annotations:
     kubernetes.io/ingress.class: "nginx"
@@ -11,7 +11,7 @@ metadata:
       more_set_headers "X-Robots-Tag: noindex";
 spec:
   tls:
-  - secretName: staging-insights-ubuntu-com-tls
+  - secretName: insights-staging-ubuntu-com-tls
     hosts:
     - insights.staging.ubuntu.com
   rules:
@@ -20,7 +20,7 @@ spec:
       paths:
       - path: /
         backend:
-          serviceName: insights.staging.ubuntu.com
+          serviceName: insights-ubuntu-com
           servicePort: 80
 
 ---

--- a/ingresses/staging/insights.staging.ubuntu.com.yaml
+++ b/ingresses/staging/insights.staging.ubuntu.com.yaml
@@ -1,0 +1,26 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: staging-insights-ubuntu-com
+  namespace: staging
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "X-Robots-Tag: noindex";
+spec:
+  tls:
+  - secretName: staging-insights-ubuntu-com-tls
+    hosts:
+    - insights.staging.ubuntu.com
+  rules:
+  - host: insights.staging.ubuntu.com
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: insights.staging.ubuntu.com
+          servicePort: 80
+
+---

--- a/services/insights.ubuntu.com.yaml
+++ b/services/insights.ubuntu.com.yaml
@@ -1,0 +1,49 @@
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: insights-ubuntu-com
+spec:
+  selector:
+    app: insights.ubuntu.com
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http
+
+---
+
+kind: Deployment
+apiVersion: apps/v1beta1
+metadata:
+  name: insights-ubuntu-com
+spec:
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        app: insights.ubuntu.com
+    spec:
+      containers:
+        - name: insights-ubuntu-com
+          image: prod-comms.docker-registry.canonical.com/insights.ubuntu.com:${TAG_TO_DEPLOY}
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            periodSeconds: 3
+            successThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 5
+
+---


### PR DESCRIPTION
## Done
Added insights.ubuntu.com

## QA

``` bash
# Install VirtualBox if you haven't got it
sudo apt install virtualbox

# Install minikube if you haven't already
curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.22.3/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/

# Enable Ingress add-on
minikube addons enable ingress

# Get minkube running
minikube start
kubectl config set-context minikube  # To be on the safe side

# Deploy new configs to minikube
cat services/insights.ubuntu.com.yaml | sed 's|prod-comms.docker-registry.canonical.com/insights.ubuntu.com|canonicalwebteam/www.ubuntu.com|' | sed 's|[:][$][{]TAG_TO_DEPLOY[}]||' | sed 's|replicas: 5|replicas: 1|' | kubectl apply --namespace staging --filename -
cat services/insights.ubuntu.com.yaml | sed 's|prod-comms.docker-registry.canonical.com/insights.ubuntu.com|canonicalwebteam/www.ubuntu.com|' | sed 's|[:][$][{]TAG_TO_DEPLOY[}]||' | sed 's|replicas: 5|replicas: 1|' | kubectl apply --namespace production --filename -
kubectl apply --namespace staging --filename ingresses/staging/insights.staging.ubuntu.com.yaml
kubectl apply --namespace production --filename ingresses/production/insights.ubuntu.com.yaml

# Check everything deployed correctly
kubectl get ingress,service,deployment,pod --namespace staging  # Inspect staging elements
kubectl get ingress,service,deployment,pod --namespace production  # Inspect production elements

# Curl the site, check for 200 status
curl -I -H 'Host: insights.ubuntu.com' `minikube ip`
curl -I -H 'Host: insights.staging.ubuntu.com' `minikube ip`
```