### PR TITLE
Add tooling for creating new projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,20 @@ The [ingress resources](https://kubernetes.io/docs/concepts/services-networking/
 
 ## Deploying
 
+### Using create-project
+
+When creating a new project you can either copy an existing projects service and ingress files. Then replace the config strings with the new project configs. 
+
+Or, use `./create-project`. To auto generate the files for a new project. Run `./create-project project.name` and the tool will create the config files for you. 
+
+For example:
+`./create-project www.ubuntu.com`
+
+Will create:
+ - /service/www.ubuntu.com.yaml
+ - /ingresses/staging/www.staging.ubuntu.com.yaml
+ - /ingresses/production/www.ubuntu.com.yaml
+
 ### To deploy a new service
 
 E.g. to deploy the snapcraft.io service to staging from scratch:

--- a/create-project
+++ b/create-project
@@ -1,0 +1,67 @@
+#! /usr/bin/python3
+
+import sys
+
+from shutil import copyfile
+
+project = sys.argv[1]
+
+def create_service(project):
+    service_file_name = 'services/%s.yaml' % project
+    copyfile('templates/service.yaml', service_file_name)
+    update_file(service_file_name, project)
+
+
+def create_ingresses(project, enviroments):
+    project_split = project.split('.')
+    
+    for enviroment in enviroments:
+        
+        # Add the enviroment between the domain if subdomain
+        if len(project_split) > 2:
+            file_name = '%s.%s.%s.%s.yaml' % (
+                project_split[0], 
+                enviroment,
+                project_split[1], 
+                project_split[2]
+            )
+        else:
+            file_name = '%s.%s.yaml' % (
+                enviroment,
+                project
+            )
+        
+        src = 'templates/%s.yaml' % enviroment
+        dst = 'ingresses/%s/%s' % (
+            enviroment,
+            file_name
+        )
+        
+        # Remove production from the file and project naming
+        if enviroment == 'production':
+            file_name = file_name.replace('production.', '')
+            dst = dst.replace('production.', '')
+
+        copyfile(src, dst)
+        update_file(dst, file_name)
+
+
+def update_file(file_name, project):
+    project = project.replace('.yaml', '')
+    project_name = project.replace('.', '-')
+    project_domain = project
+    prod_project_name = project_name.replace('staging-', '')
+    with open(file_name) as file_handle:
+        file_contents = file_handle.read()
+
+    file_contents = file_contents.replace('PRODPROJECTNAME', prod_project_name)
+    file_contents = file_contents.replace('PROJECTNAME', project_name)
+    file_contents = file_contents.replace('PROJECTDOMAIN', project_domain)
+
+    with open(file_name, 'w') as file_handle:
+        file_handle.write(file_contents)
+
+
+create_service(project)
+create_ingresses(project, ['staging', 'production'])
+

--- a/templates/production.yaml
+++ b/templates/production.yaml
@@ -1,0 +1,24 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: PROJECTNAME
+  namespace: production
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  tls:
+  - secretName: PROJECTNAME-tls
+    hosts:
+    - PROJECTDOMAIN
+  rules:
+  - host: PROJECTDOMAIN
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: PROJECTNAME
+          servicePort: 80
+
+---

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -1,0 +1,49 @@
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: PROJECTNAME
+spec:
+  selector:
+    app: PROJECTDOMAIN
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http
+
+---
+
+kind: Deployment
+apiVersion: apps/v1beta1
+metadata:
+  name: PROJECTNAME
+spec:
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        app: PROJECTDOMAIN
+    spec:
+      containers:
+        - name: PROJECTNAME
+          image: prod-comms.docker-registry.canonical.com/PROJECTDOMAIN:${TAG_TO_DEPLOY}
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            periodSeconds: 3
+            successThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 5
+
+---

--- a/templates/staging.yaml
+++ b/templates/staging.yaml
@@ -1,0 +1,26 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: PROJECTNAME
+  namespace: staging
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "X-Robots-Tag: noindex";
+spec:
+  tls:
+  - secretName: PROJECTNAME-tls
+    hosts:
+    - PROJECTDOMAIN
+  rules:
+  - host: PROJECTDOMAIN
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: PRODPROJECTNAME
+          servicePort: 80
+
+---


### PR DESCRIPTION
## Done
Added a script to generate a new projects configs automatically

## QA

### Create configs for top-level domain

- Run `./create-project ubuntu.io`
- Check it creates 3 files correctly


### Create configs for subdomain

- Run `./create-project www.ubuntu.com`
- Check it creates 3 files (service, production ingress and staging ingress)

### Test deployments with minikube

``` bash
# Install VirtualBox if you haven't got it
sudo apt install virtualbox

# Install minikube if you haven't already
curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.22.3/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/

# Enable Ingress add-on
minikube addons enable ingress

# Get minkube running
minikube start
kubectl config set-context minikube  # To be on the safe side

# Deploy new deployments to minikube (with snapcraft.io image for simplicity)
envsubst < services/ubuntu.io.yaml | sed 's|prod-comms.docker-registry.canonical.com/.*:[$][{]TAG_TO_DEPLOY[}]|canonicalwebteam/snapcraft.io|' | kubectl apply --namespace staging --filename -
envsubst < services/www.ubuntu.com.yaml | sed 's|prod-comms.docker-registry.canonical.com/.*:[$][{]TAG_TO_DEPLOY[}]|canonicalwebteam/snapcraft.io|' | kubectl apply --namespace staging --filename -
envsubst < services/ubuntu.io.yaml | sed 's|prod-comms.docker-registry.canonical.com/.*:[$][{]TAG_TO_DEPLOY[}]|canonicalwebteam/snapcraft.io|' | kubectl apply --namespace production --filename -
envsubst < services/www.ubuntu.com.yaml | sed 's|prod-comms.docker-registry.canonical.com/.*:[$][{]TAG_TO_DEPLOY[}]|canonicalwebteam/snapcraft.io|' | kubectl apply --namespace production --filename -

# Deploy new ingresses
kubectl apply --namespace staging --filename ingresses/staging/staging.ubuntu.io.yaml
kubectl apply --namespace staging --filename ingresses/staging/www.staging.ubuntu.com.yaml
kubectl apply --namespace production --filename ingresses/production/ubuntu.io.yaml
kubectl apply --namespace production --filename ingresses/production/www.ubuntu.com.yaml

# Check everything deployed correctly
kubectl get ingress,service,deployment,pod --namespace staging  # Inspect staging elements
kubectl get ingress,service,deployment,pod --namespace production  # Inspect production elements

# Curl the sites, check for 200 status
curl -I -H 'Host: ubuntu.io' `minikube ip`
curl -I -H 'Host: staging.ubuntu.io' `minikube ip`
curl -I -H 'Host: www.ubuntu.com' `minikube ip`
curl -I -H 'Host: www.staging.ubuntu.com' `minikube ip`
```
