### PR TITLE
Send docs.ubuntu.com/phone to a different image

### DIFF
--- a/ingresses/production/docs.ubuntu.com.yaml
+++ b/ingresses/production/docs.ubuntu.com.yaml
@@ -6,7 +6,6 @@ metadata:
   name: docs-ubuntu-com
   namespace: production
   annotations:
-    ingress.kubernetes.io/rewrite-target: /
     kubernetes.io/ingress.class: "nginx"
 spec:
   tls:

--- a/ingresses/production/docs.ubuntu.com.yaml
+++ b/ingresses/production/docs.ubuntu.com.yaml
@@ -6,6 +6,7 @@ metadata:
   name: docs-ubuntu-com
   namespace: production
   annotations:
+    ingress.kubernetes.io/rewrite-target: /
     kubernetes.io/ingress.class: "nginx"
 spec:
   tls:
@@ -19,6 +20,10 @@ spec:
       - path: /
         backend:
           serviceName: docs-ubuntu-com
+          servicePort: 80
+      - path: /phone
+        backend:
+          serviceName: docs-ubuntu-com-phone
           servicePort: 80
 
 ---

--- a/ingresses/staging/docs.staging.ubuntu.com.yaml
+++ b/ingresses/staging/docs.staging.ubuntu.com.yaml
@@ -7,7 +7,6 @@ metadata:
   namespace: staging
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    ingress.kubernetes.io/rewrite-target: /
     ingress.kubernetes.io/configuration-snippet: |
       more_set_headers "X-Robots-Tag: noindex";
 spec:

--- a/ingresses/staging/docs.staging.ubuntu.com.yaml
+++ b/ingresses/staging/docs.staging.ubuntu.com.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: staging
   annotations:
     kubernetes.io/ingress.class: "nginx"
+    ingress.kubernetes.io/rewrite-target: /
     ingress.kubernetes.io/configuration-snippet: |
       more_set_headers "X-Robots-Tag: noindex";
 spec:
@@ -21,6 +22,10 @@ spec:
       - path: /
         backend:
           serviceName: docs-ubuntu-com
+          servicePort: 80
+      - path: /phone
+        backend:
+          serviceName: docs-ubuntu-com-phone
           servicePort: 80
 
 ---

--- a/services/docs.ubuntu.com.yaml
+++ b/services/docs.ubuntu.com.yaml
@@ -15,6 +15,21 @@ spec:
 
 ---
 
+kind: Service
+apiVersion: v1
+metadata:
+  name: docs-ubuntu-com-phone
+spec:
+  selector:
+    app: docs.ubuntu.com-phone
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http
+
+---
+
 kind: Deployment
 apiVersion: apps/v1beta1
 metadata:
@@ -29,6 +44,39 @@ spec:
       containers:
         - name: docs-ubuntu-com
           image: prod-comms.docker-registry.canonical.com/docs.ubuntu.com:${TAG_TO_DEPLOY}
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            periodSeconds: 3
+            successThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 5
+
+---
+
+kind: Deployment
+apiVersion: apps/v1beta1
+metadata:
+  name: docs-ubuntu-com-phone
+spec:
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        app: docs.ubuntu.com-phone
+    spec:
+      containers:
+        - name: docs-ubuntu-com-phone
+          image: prod-comms.docker-registry.canonical.com/docs.ubuntu.com-phone:${TAG_TO_DEPLOY}
           imagePullPolicy: Always
           ports:
             - name: http


### PR DESCRIPTION
Fixes https://github.com/canonical-websites/docs.ubuntu.com/issues/102

## QA

Let's assume you've got [minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/) installed.

``` bash
minikube start
minikube addons enable ingress
cat services/docs.ubuntu.com.yaml | sed 's|prod-comms.docker-registry.canonical.com|canonicalwebteam|' | sed 's|[:][$][{]TAG_TO_DEPLOY[}]||' | sed 's|replicas: 5|replicas: 1|' | kubectl apply --namespace staging --filename -
cat services/docs.ubuntu.com.yaml | sed 's|prod-comms.docker-registry.canonical.com|canonicalwebteam|' | sed 's|[:][$][{]TAG_TO_DEPLOY[}]||' | sed 's|replicas: 5|replicas: 1|' | kubectl apply --namespace production --filename -
kubectl apply -f ingresses/staging/docs.staging.ubuntu.com.yaml
kubectl apply -f ingresses/production/docs.ubuntu.com.yaml
# Wait a couple of minutes
curl -I -H 'Host: docs.ubuntu.com' `minikube ip`  # Should give you 200 OK
curl -I -H 'Host: docs.ubuntu.com' `minikube ip`/phone  # Should redirect you to /phone/en/
curl -I -H 'Host: docs.ubuntu.com' `minikube ip`/phone/en/apps/  # Should give you 200 OK
curl -I -H 'Host: docs.ubuntu.com' `minikube ip`/phone/en/apps  # Should redirect you to /phone/en/apps/
curl -I -H 'Host: docs.ubuntu.com' `minikube ip`/phone/en/apps/index  # Should redirect you to /phone/en/apps/
curl -I -H 'Host: docs.staging.ubuntu.com' `minikube ip`  # Should give you 200 OK
curl -I -H 'Host: docs.staging.ubuntu.com' `minikube ip`/phone  # Should redirect you to /phone/en/
curl -I -H 'Host: docs.staging.ubuntu.com' `minikube ip`/phone/en/apps/  # Should give you 200 OK
curl -I -H 'Host: docs.staging.ubuntu.com' `minikube ip`/phone/en/apps  # Should redirect you to /phone/en/apps/
curl -I -H 'Host: docs.staging.ubuntu.com' `minikube ip`/phone/en/apps/index  # Should redirect you to /phone/en/apps/
```