### PR TITLE
Redirect www.snapcraft.io to snapcraft.io

### DIFF
--- a/ingresses/production/snapcraft.io.yaml
+++ b/ingresses/production/snapcraft.io.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: production
   annotations:
     kubernetes.io/ingress.class: "nginx"
+    ingress.kubernetes.io/from-to-www-redirect: "true"
 spec:
   tls:
   - secretName: snapcraft-io-tls


### PR DESCRIPTION
To resolve https://portal.admin.canonical.com/106888

QA
--

(Pssst... you need [minikube](https://github.com/kubernetes/minikube/releases) with [the ingress addon](https://www.ibm.com/support/knowledgecenter/en/SS5PWC/front_end_config_minikube_task.html))

``` bash
minikube start
```

Now, edit `ingresses/production/snapcraft.io.yaml` and comment out the `namespace: production` line. Then run:

``` bash
$ kubectl -f apply ingresses/production/snapcraft.io.yaml
$ # Wait a bit... then
$ curl -I -H 'Host: www.snapcraft.io' 192.168.99.100                                                       
HTTP/1.1 301 Moved Permanently
```