### PR TITLE
www.snapcraft.io -> snapcraft.io with TLS support

### DIFF
--- a/ingresses/production/snapcraft.io.yaml
+++ b/ingresses/production/snapcraft.io.yaml
@@ -7,18 +7,27 @@ metadata:
   namespace: production
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    ingress.kubernetes.io/from-to-www-redirect: "true"
+    ingress.kubernetes.io/configuration-snippet: |
+      if ($host = 'www.snapcraft.io' ) {
+        rewrite ^ https://snapcraft.io$request_uri permanent;
+      }
 spec:
   tls:
   - secretName: snapcraft-io-tls
     hosts:
     - snapcraft.io
+    - www.snapcraft.io
   rules:
   - host: snapcraft.io
     http:
       paths:
-      - path: /
-        backend:
+      - backend:
+          serviceName: snapcraft-io
+          servicePort: 80
+  - host: www.snapcraft.io
+    http:
+      paths:
+      - backend:
           serviceName: snapcraft-io
           servicePort: 80
 


### PR DESCRIPTION
This should make it so https://www.snapcraft.io can redirect to https://snapcraft.io without a certificate error.
    
We initially wanted to use [the redirect-from-to-www annotation](https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/annotations.md#redirect-from-to-www), as this is nice and neat, but unfortunately that [isn't able to serve a TLS certificate for the redirected domain](https://github.com/kubernetes/ingress-nginx/issues/605).
    
Until that's fixed, we have to use this solution, [as others are doing](https://github.com/kubernetes/ingress-nginx/issues/605#issuecomment-334931436).
    
(It would also help to make this more DRY if we were able to [specify multiple hosts in a http rule](https://github.com/kubernetes/kubernetes/issues/43633))


QA
--

To test this in your local `minikube` you'll need to duplicate the valid `snapcraft-io-tls` secret containing that valid certificate from production. If you don't know how to do this, ask me.

Then, edit `services/snapcraft.io.yaml` to change `5` units to `1` (unless you're running a supercomputer), and edit `ingresses/production/snapcraft.io.yaml` to comment out the `namespace: production` line.

Now deploy things:

``` bash
kubectl apply -f services/snapcraft.io.yaml
kubectl apply -f ingresses/production/snapcraft.io.yaml
```

Edit your `/etc/hosts` to point `snapcraft.io` and `www.snapcraft.io` at your minikube IP.

Now test that `https://www.snapcraft.io` redirects:

``` bash
$ curl -I https://www.snapcraft.io
HTTP/1.1 301 Moved Permanently
Location: https://snapcraft.io/
```