### PR TITLE
Add tutorials.ubuntu.com config

### DIFF
--- a/ingresses/production/tutorials.ubuntu.com.yaml
+++ b/ingresses/production/tutorials.ubuntu.com.yaml
@@ -1,0 +1,24 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: tutorials-ubuntu-com
+  namespace: production
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  tls:
+  - secretName: tutorials-ubuntu-com-tls
+    hosts:
+    - tutorials.ubuntu.com
+  rules:
+  - host: tutorials.ubuntu.com
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: tutorials-ubuntu-com
+          servicePort: 80
+
+---

--- a/ingresses/staging/tutorials.staging.ubuntu.com.yaml
+++ b/ingresses/staging/tutorials.staging.ubuntu.com.yaml
@@ -1,0 +1,26 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: tutorials-staging-ubuntu-com
+  namespace: staging
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "X-Robots-Tag: noindex";
+spec:
+  tls:
+  - secretName: tutorials-staging-ubuntu-com-tls
+    hosts:
+    - tutorials.staging.ubuntu.com
+  rules:
+  - host: tutorials.staging.ubuntu.com
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: tutorials-ubuntu-com
+          servicePort: 80
+
+---

--- a/services/tutorials.ubuntu.com.yaml
+++ b/services/tutorials.ubuntu.com.yaml
@@ -1,0 +1,49 @@
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: tutorials-ubuntu-com
+spec:
+  selector:
+    app: tutorials.ubuntu.com
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http
+
+---
+
+kind: Deployment
+apiVersion: apps/v1beta1
+metadata:
+  name: tutorials-ubuntu-com
+spec:
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        app: tutorials.ubuntu.com
+    spec:
+      containers:
+        - name: tutorials-ubuntu-com
+          image: prod-comms.docker-registry.canonical.com/tutorials.ubuntu.com:${TAG_TO_DEPLOY}
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            periodSeconds: 3
+            successThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 5
+
+---


### PR DESCRIPTION
## Done
Added tutorials.ubuntu.com

## QA

``` bash
# Install VirtualBox if you haven't got it
sudo apt install virtualbox

# Install minikube if you haven't already
curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.22.3/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/

# Enable Ingress add-on
minikube addons enable ingress

# Get minkube running
minikube start
kubectl config set-context minikube  # To be on the safe side

# Deploy new configs to minikube
cat services/tutorials.ubuntu.com.yaml | sed 's|prod-comms.docker-registry.canonical.com/tutorials.ubuntu.com|canonicalwebteam/tutorials.ubuntu.com|' | sed 's|[:][$][{]TAG_TO_DEPLOY[}]||' | sed 's|replicas: 5|replicas: 1|' | kubectl apply --namespace staging --filename -
cat services/tutorials.ubuntu.com.yaml | sed 's|prod-comms.docker-registry.canonical.com/tutorials.ubuntu.com|canonicalwebteam/tutorials.ubuntu.com|' | sed 's|[:][$][{]TAG_TO_DEPLOY[}]||' | sed 's|replicas: 5|replicas: 1|' | kubectl apply --namespace production --filename -
kubectl apply --namespace staging --filename ingresses/staging/tutorials.staging.ubuntu.com.yaml
kubectl apply --namespace production --filename ingresses/production/tutorials.ubuntu.com.yaml

# Check everything deployed correctly
kubectl get ingress,service,deployment,pod --namespace staging  # Inspect staging elements
kubectl get ingress,service,deployment,pod --namespace production  # Inspect production elements

# Curl the site, check for 200 status
curl -I -H 'Host: tutorials.ubuntu.com' `minikube ip`
curl -I -H 'Host: tutorials.staging.ubuntu.com' `minikube ip`
```