### PR TITLE
Add docs.ubuntu.com/core image

### DIFF
--- a/ingresses/production/docs.ubuntu.com.yaml
+++ b/ingresses/production/docs.ubuntu.com.yaml
@@ -20,6 +20,10 @@ spec:
         backend:
           serviceName: docs-ubuntu-com
           servicePort: 80
+      - path: /core
+        backend:
+          serviceName: docs-ubuntu-com-core
+          servicePort: 80
       - path: /phone
         backend:
           serviceName: docs-ubuntu-com-phone

--- a/ingresses/staging/docs.staging.ubuntu.com.yaml
+++ b/ingresses/staging/docs.staging.ubuntu.com.yaml
@@ -22,6 +22,10 @@ spec:
         backend:
           serviceName: docs-ubuntu-com
           servicePort: 80
+      - path: /core
+        backend:
+          serviceName: docs-ubuntu-com-core
+          servicePort: 80
       - path: /phone
         backend:
           serviceName: docs-ubuntu-com-phone

--- a/services/docs.ubuntu.com.yaml
+++ b/services/docs.ubuntu.com.yaml
@@ -91,7 +91,7 @@ spec:
     spec:
       containers:
         - name: docs-ubuntu-com-core
-          image: prod-comms.docker-registry.canonical.com/docs.ubuntu.com-core:${TAG_TO_DEPLOY_core}
+          image: prod-comms.docker-registry.canonical.com/docs.ubuntu.com-core:${TAG_TO_DEPLOY_CORE}
           imagePullPolicy: Always
           ports:
             - name: http
@@ -124,7 +124,7 @@ spec:
     spec:
       containers:
         - name: docs-ubuntu-com-phone
-          image: prod-comms.docker-registry.canonical.com/docs.ubuntu.com-phone:${TAG_TO_DEPLOY_phone}
+          image: prod-comms.docker-registry.canonical.com/docs.ubuntu.com-phone:${TAG_TO_DEPLOY_PHONE}
           imagePullPolicy: Always
           ports:
             - name: http

--- a/services/docs.ubuntu.com.yaml
+++ b/services/docs.ubuntu.com.yaml
@@ -18,6 +18,21 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
+  name: docs-ubuntu-com-core
+spec:
+  selector:
+    app: docs.ubuntu.com-core
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http
+
+---
+
+kind: Service
+apiVersion: v1
+metadata:
   name: docs-ubuntu-com-phone
 spec:
   selector:
@@ -44,6 +59,39 @@ spec:
       containers:
         - name: docs-ubuntu-com
           image: prod-comms.docker-registry.canonical.com/docs.ubuntu.com:${TAG_TO_DEPLOY}
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            periodSeconds: 3
+            successThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 5
+
+---
+
+kind: Deployment
+apiVersion: apps/v1beta1
+metadata:
+  name: docs-ubuntu-com-core
+spec:
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        app: docs.ubuntu.com-core
+    spec:
+      containers:
+        - name: docs-ubuntu-com-core
+          image: prod-comms.docker-registry.canonical.com/docs.ubuntu.com-core:${TAG_TO_DEPLOY_core}
           imagePullPolicy: Always
           ports:
             - name: http


### PR DESCRIPTION
Point docs.ubuntu.com/core to new image
This follows the same config as docs.ubuntu.com/phone


## QA

Let's assume you've got [minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/) installed.

``` bash
# Run minikube
minikube start
minikube addons enable ingress

# Create the service
cat services/docs.ubuntu.com.yaml | sed 's|prod-comms.docker-registry.canonical.com|canonicalwebteam|' | sed 's|[:][$][{]TAG_TO_DEPLOY[_aa-zA-Z]*[}]||' | sed 's|replicas: 5|replicas: 1|' | kubectl apply --filename -

# Create the ingress domains
cat ingresses/staging/docs.staging.ubuntu.com.yaml | sed '/namespace:/d' | kubectl apply --filename -
cat ingresses/production/docs.ubuntu.com.yaml | sed '/namespace:/d' | kubectl apply --filename -

# Wait a couple of minutes

# Test everything with curl
curl -I -H 'Host: docs.ubuntu.com' `minikube ip`  # Should give you 200 OK
curl -I -H 'Host: docs.ubuntu.com' `minikube ip`/core  # Should redirect you to /core/en/
curl -I -H 'Host: docs.ubuntu.com' `minikube ip`/core/en/stacks/  # Should give you 200 OK
curl -I -H 'Host: docs.ubuntu.com' `minikube ip`/core/en/stacks  # Should redirect you to /core/en/stacks/
curl -I -H 'Host: docs.ubuntu.com' `minikube ip`/core/en/stacks/index  # Should redirect you to /core/en/stacks/
curl -I -H 'Host: docs.staging.ubuntu.com' `minikube ip`  # Should give you 200 OK
curl -I -H 'Host: docs.staging.ubuntu.com' `minikube ip`/core  # Should redirect you to /core/en/
curl -I -H 'Host: docs.staging.ubuntu.com' `minikube ip`/core/en/stacks/  # Should give you 200 OK
curl -I -H 'Host: docs.staging.ubuntu.com' `minikube ip`/core/en/stacks  # Should redirect you to /core/en/stacks/
curl -I -H 'Host: docs.staging.ubuntu.com' `minikube ip`/core/en/stacks/index  # Should redirect you to /core/en/stacks/