### PR TITLE
Add configmap

### DIFF
--- a/namespaces.yaml
+++ b/namespaces.yaml
@@ -13,3 +13,41 @@ metadata:
   name: staging
 
 ---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: proxy-config
+data:
+  HTTP_PROXY: 'http://squid.internal:3128/'
+  HTTPS_PROXY: 'http://squid.internal:3128/'
+
+---
+
+apiVersion: settings.k8s.io/v1alpha1
+kind: PodPreset
+metadata:
+  name: global-proxy-config
+  namespace: production
+spec:
+  selector:
+    matchLabels:
+      useProxy: "true"
+  envFrom:
+    - configMapRef:
+        name: proxy-config
+
+---
+
+apiVersion: settings.k8s.io/v1alpha1
+kind: PodPreset
+metadata:
+  name: global-proxy-config
+  namespace: staging
+spec:
+  selector:
+    matchLabels:
+      useProxy: "true"
+  envFrom:
+    - configMapRef:
+        name: proxy-config

--- a/qa-deploy
+++ b/qa-deploy
@@ -11,6 +11,7 @@ USAGE="Usage
 Description
 ---
 Deploy locally to minikube.
+You must be connected to the Canonical VPN to use this script.
 "
 
 function invalid() {
@@ -21,6 +22,28 @@ function invalid() {
     exit 1
 }
 
+function add_docker_credentials_minikube() {
+    if ! kubectl get secret registry-access &> /dev/null; then
+
+        username=""
+        password=""
+        while [[ -z "${username}" || -z "${password}" ]]; do
+            echo "##############"
+            echo "Docker registry credentials"
+            echo
+            echo -n "Username: "
+            read username
+            echo -n "Password: "
+            read -s password
+            echo -e "\n##############"
+        done
+
+        kubectl create secret docker-registry registry-access --docker-server=prod-comms.docker-registry.canonical.com --docker-username="${username}" --docker-password="${password}" --docker-email=root@localhost
+
+        kubectl patch serviceaccount default -p '{"imagePullSecrets": [{"name": "registry-access"}]}' --namespace default
+    fi
+}
+
 function run_minikube() {
     # Run minikube
     if ! minikube ip &> /dev/null; then
@@ -28,13 +51,14 @@ function run_minikube() {
     fi
 
     minikube addons enable ingress
+
     kubectl config set-context minikube
 }
 
 function deploy_service() {
     service="${1}"
 
-    cat "services/${service}.yaml" | sed 's|prod-comms.docker-registry.canonical.com|canonicalwebteam|' | sed 's|[:][$][{]TAG_TO_DEPLOY[_aa-zA-Z]*[}]||' | sed 's|replicas: [0-9][0-9]*|replicas: 1|' | kubectl apply --filename -
+    cat "services/${service}.yaml" | sed 's|[:][$][{]TAG_TO_DEPLOY[_aa-zA-Z]*[}]||' | sed 's|replicas: [0-9][0-9]*|replicas: 1|' | kubectl apply --filename -
 }
 
 function deploy_ingress() {
@@ -44,11 +68,18 @@ function deploy_ingress() {
 }
 
 function run() {
+    echo -n "Are you connected to the VPN? [Y/n] "
+    read vpn
+
+    if [ "${vpn}" == "n" ]; then exit 0; fi
+
     production="${1:-}"
     staging="${2:-}"
     if [ -z "${production}" ]; then invalid "Missing production url"; fi
 
     run_minikube
+
+    add_docker_credentials_minikube
 
     deploy_service "${production}"
 

--- a/qa-deploy
+++ b/qa-deploy
@@ -1,0 +1,60 @@
+#! /usr/bin/env bash
+
+# Bash strict mode
+set -euo pipefail
+
+USAGE="Usage
+===
+
+  $ ./qa-deploy PRODUCTION_URL [STAGING_URL]
+
+Description
+---
+Deploy locally to minikube.
+"
+
+function invalid() {
+    message=${1}
+    echo "Error: ${message}"
+    echo ""
+    echo "$USAGE"
+    exit 1
+}
+
+function run_minikube() {
+    # Run minikube
+    if ! minikube ip &> /dev/null; then
+        minikube start
+    fi
+
+    minikube addons enable ingress
+    kubectl config set-context minikube
+}
+
+function deploy_service() {
+    service="${1}"
+
+    cat "services/${service}.yaml" | sed 's|prod-comms.docker-registry.canonical.com|canonicalwebteam|' | sed 's|[:][$][{]TAG_TO_DEPLOY[_aa-zA-Z]*[}]||' | sed 's|replicas: [0-9][0-9]*|replicas: 1|' | kubectl apply --filename -
+}
+
+function deploy_ingress() {
+    ingress="${1}"
+    # Create the ingress domains
+    cat "ingresses/${ingress}.yaml" | sed '/namespace:/d' | kubectl apply --filename -
+}
+
+function run() {
+    production="${1:-}"
+    staging="${2:-}"
+    if [ -z "${production}" ]; then invalid "Missing production url"; fi
+
+    run_minikube
+
+    deploy_service "${production}"
+
+    deploy_ingress "production/${production}"
+
+    if [ -n "${staging}" ]; then deploy_ingress "staging/${staging}"; fi
+}
+
+run ${@}

--- a/services/insights.ubuntu.com.yaml
+++ b/services/insights.ubuntu.com.yaml
@@ -4,6 +4,8 @@ kind: Service
 apiVersion: v1
 metadata:
   name: insights-ubuntu-com
+  labels:
+    useProxy: "true"
 spec:
   selector:
     app: insights.ubuntu.com
@@ -19,6 +21,8 @@ kind: Deployment
 apiVersion: apps/v1beta1
 metadata:
   name: insights-ubuntu-com
+  labels:
+    useProxy: "true"
 spec:
   replicas: 5
   template:


### PR DESCRIPTION
Pair programmed with @WillMoggridge 

# Summary

The HTTP_PROXY variable wasn't configured on our instance of k8s. To manage this we used configMap that allows us to add variables and give them to the services that needs it (here insights).

To make it easier to qa we created a script that deploys automatically locally to staging and production:

```
Usage
===

  $ ./qa-deploy PRODUCTION_URL [STAGING_URL]

Description
---
Deploy locally to minikube.
```

# QA
```
./qa-deploy insights.ubuntu.com insights.staging.ubuntu.com
curl -I -H 'Host: insights.staging.ubuntu.com' `minikube ip` #  200 OK
```
