### PR TITLE
Add usn.ubuntu.com

### DIFF
--- a/ingresses/production/usn.ubuntu.com.yaml
+++ b/ingresses/production/usn.ubuntu.com.yaml
@@ -1,0 +1,24 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: usn-ubuntu-com
+  namespace: production
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  tls:
+  - secretName: usn-ubuntu-com-tls
+    hosts:
+    - usn.ubuntu.com
+  rules:
+  - host: usn.ubuntu.com
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: usn-ubuntu-com
+          servicePort: 80
+
+---

--- a/services/usn.ubuntu.com.yaml
+++ b/services/usn.ubuntu.com.yaml
@@ -1,0 +1,49 @@
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: usn-ubuntu-com
+spec:
+  selector:
+    app: usn.ubuntu.com
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http
+
+---
+
+kind: Deployment
+apiVersion: apps/v1beta1
+metadata:
+  name: usn-ubuntu-com
+spec:
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        app: usn.ubuntu.com
+    spec:
+      containers:
+        - name: usn-ubuntu-com
+          image: prod-comms.docker-registry.canonical.com/usn.ubuntu.com:${TAG_TO_DEPLOY}
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            periodSeconds: 3
+            successThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 5
+
+---


### PR DESCRIPTION
Add usn.ubuntu.com deployment config


## QA

Let's assume you've got [minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/) installed.

``` bash
# Run minikube if not started
minikube start
minikube addons enable ingress

# Change context to minikube to be safe
kubectl config use-context minikube

# Create the service
cat services/usn.ubuntu.com.yaml | sed 's|prod-comms.docker-registry.canonical.com|canonicalwebteam|' | sed 's|[:][$][{]TAG_TO_DEPLOY[_aa-zA-Z]*[}]||' | sed 's|replicas: 5|replicas: 1|' | kubectl apply --filename -

# Create the ingress domain
cat ingresses/production/usn.ubuntu.com.yaml | sed '/namespace:/d' | kubectl apply --filename -

# Wait a couple of minutes

# Test with curl
curl -I -H 'Host: usn.ubuntu.com' `minikube ip`  # Should give you 200 OK