### PR TITLE
Add rendertron internal service

### DIFF
--- a/services/rendertron.yaml
+++ b/services/rendertron.yaml
@@ -3,51 +3,47 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: tutorials-ubuntu-com
+  name: rendertron
 spec:
   selector:
-    app: tutorials.ubuntu.com
+    app: rendertron
   ports:
     - name: http
       protocol: TCP
       port: 80
-      targetPort: http
+      targetPort: 8080
 
 ---
 
 kind: Deployment
 apiVersion: apps/v1beta1
 metadata:
-  name: tutorials-ubuntu-com
+  name: rendertron
 spec:
-  replicas: 5
+  replicas: 1
   template:
     metadata:
       labels:
-        app: tutorials.ubuntu.com
+        app: rendertron
     spec:
       containers:
-        - name: tutorials-ubuntu-com
-          image: prod-comms.docker-registry.canonical.com/tutorials.ubuntu.com:${TAG_TO_DEPLOY}
+        - name: rendertron
+          image: prod-comms.docker-registry.canonical.com/rendertron:${TAG_TO_DEPLOY}
           imagePullPolicy: Always
           ports:
             - name: http
-              containerPort: 80
-          env:
-          - name: BOT_PROXY
-            value: "http://rendertron/render"
+              containerPort: 8080
           readinessProbe:
             httpGet:
               path: /
-              port: 80
+              port: 8080
             periodSeconds: 3
             successThreshold: 3
           livenessProbe:
             httpGet:
               path: /
-              port: 80
+              port: 8080
             initialDelaySeconds: 5
             periodSeconds: 5
-
 
 ---


### PR DESCRIPTION
Add rendertron service and set the URL in Tutorials.


### QA with script
```
./qa-deploy rendertron # Expect an error about lack of ingress
./qa-deploy tutorials.ubuntu.com

# Wait a couple of minutes

# Test everything with curl
curl -H 'Host: tutorials.ubuntu.com' `minikube ip`  # Should give you "simple" HTML output
curl -H "User-Agent: Slackbot" -H 'Host: tutorials.ubuntu.com' `minikube ip` # Should give you full HTML output

# Check for output that should only show on a rendered page
curl -H "User-Agent: Slackbot" -H 'Host: tutorials.ubuntu.com' `minikube ip` -I | grep 'x-renderer'

```



### Older QA instructions here:

```
# Run minikube
minikube start
minikube addons enable ingress
kubectl config use-context minikube

# Create the service
cat services/tutorials.ubuntu.com.yaml | sed 's|prod-comms.docker-registry.canonical.com|canonicalwebteam|' | sed 's|[:][$][{]TAG_TO_DEPLOY[_aa-zA-Z]*[}]||' | sed 's|replicas: 5|replicas: 1|' | kubectl apply --filename -
cat services/rendertron.yaml | sed 's|prod-comms.docker-registry.canonical.com|canonicalwebteam|' | sed 's|[:][$][{]TAG_TO_DEPLOY[_aa-zA-Z]*[}]||' | sed 's|replicas: 2|replicas: 1|' | kubectl apply --filename -

# Create the ingress domains
cat ingresses/production/tutorials.ubuntu.com.yaml | sed '/namespace:/d'  | kubectl apply --filename -

# Wait a couple of minutes

# Test everything with curl
curl -H 'Host: tutorials.ubuntu.com' `minikube ip`  # Should give you "simple" HTML output
curl -H "User-Agent: Slackbot" -H 'Host: tutorials.ubuntu.com' `minikube ip` # Should give you full HTML output

# Check for output that should only show on a rendered page
curl -H "User-Agent: Slackbot" -H 'Host: tutorials.ubuntu.com' `minikube ip` -I | grep 'x-renderer'
```