### PR TITLE
Set SECRET_KEY env var from secret

### DIFF
--- a/services/snapcraft.io.yaml
+++ b/services/snapcraft.io.yaml
@@ -33,6 +33,12 @@ spec:
           ports:
             - name: http
               containerPort: 80
+          env:
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: snapcraft-io-config
+                  key: secret_key
           readinessProbe:
             httpGet:
               path: /


### PR DESCRIPTION
For the snapcraft.io service, get the SECRET_KEY for the app from a
secret called snapcraft-io-config.