### PR TITLE
Tweak useProxy config for insights.ubuntu.com

### DIFF
--- a/config.production.yaml
+++ b/config.production.yaml
@@ -2,6 +2,18 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: proxy-config
+  namespace: production
+data:
+  HTTP_PROXY: 'http://squid.internal:3128/'
+  HTTPS_PROXY: 'http://squid.internal:3128/'
+
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: proxy-config
+  namespace: staging
 data:
   HTTP_PROXY: 'http://squid.internal:3128/'
   HTTPS_PROXY: 'http://squid.internal:3128/'

--- a/services/insights.ubuntu.com.yaml
+++ b/services/insights.ubuntu.com.yaml
@@ -4,8 +4,6 @@ kind: Service
 apiVersion: v1
 metadata:
   name: insights-ubuntu-com
-  labels:
-    useProxy: "true"
 spec:
   selector:
     app: insights.ubuntu.com
@@ -29,6 +27,7 @@ spec:
     metadata:
       labels:
         app: insights.ubuntu.com
+        useProxy: "true"
     spec:
       containers:
         - name: insights-ubuntu-com


### PR DESCRIPTION
Remove the useProxy label from the service, which doesn't affect it and is superfluous.
Do set the label on the pod template so it correctly picks up the PodPreset.

Set `proxy-config` in the correct namespaces so it will be picked up correctly.