### PR TITLE
Explicitly pull in Insights proxy with optional configmap

### DIFF
--- a/services/insights.ubuntu.com.yaml
+++ b/services/insights.ubuntu.com.yaml
@@ -36,6 +36,10 @@ spec:
           ports:
             - name: http
               containerPort: 80
+          envFrom:
+            - configMapRef:
+                name: proxy-config
+                optional: true
           readinessProbe:
             httpGet:
               path: /


### PR DESCRIPTION
Explicitly set proxy for Insights as PodPreset needs to be enabled.


## QA

- Run `./qa-deploy insights.ubuntu.com`
- Run `kubectl describe pod insights.ubuntu.com-[POD-ID]` (Setting the correct pod ID)
- Output should contain:
```
    Environment Variables from:
      proxy-config  ConfigMap  Optional: true
```