### PR TITLE
Set nginx redirect code from 308 to 301

### DIFF
--- a/config.global.yaml
+++ b/config.global.yaml
@@ -1,5 +1,7 @@
 apiVersion: v1
 data:
+  # Change redirect code to 301 as 308 is not understood by social media bots
+  http-redirect-code: "301"
   map-hash-bucket-size: "128"
   proxy-buffer-size: 8k
   proxy-buffers: 4 8k


### PR DESCRIPTION
In the latest version of nginx-ingress-controller, it sets the redirect
code to 308. Is causes some issues with social media bots/crawlers which
don't seem to recognise the 308 HTTP code.

This will set the redirect code to 301 but it is not the preferrend
situation in the long term. As soon as it is reasonable to revert this
change, we should do so.
The docs for this setting can be found at:
https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/configmap.md#http-redirect-code


## QA

I don't think the latest minikube version has the changes that uses 308 or this config setting.
Here are the steps I used:

```
### Before checking out this branch

# Deploy Insights
./qa-deploy insights.ubuntu.com

# Create some test certs
openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /tmp/tls.key -out /tmp/tls.crt -subj "/CN=insights.ubuntu.com"
kubectl create secret tls insights-ubuntu-com-tls --key /tmp/tls.key --cert /tmp/tls.crt

# Test HTTPS
curl -I https://insights.ubuntu.com --resolve "insights.ubuntu.com:443:$(minikube ip)" --insecure

# Test Insights which should return 308
curl -I $(minikube ip) -H "Host: insights.ubuntu.com"


### Checkout this PR branch

# Deploy again to update the nginx config
./qa-deploy insights.ubuntu.com

# Test Insights which should return 301
curl -I $(minikube ip) -H "Host: insights.ubuntu.com"
```