### PR TITLE
Add docs.maas.io config

### DIFF
--- a/ingresses/production/docs.maas.io.yaml
+++ b/ingresses/production/docs.maas.io.yaml
@@ -1,0 +1,24 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: docs-maas-io
+  namespace: production
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  tls:
+  - secretName: docs-maas-io-tls
+    hosts:
+    - docs.maas.io
+  rules:
+  - host: docs.maas.io
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: docs-maas-io
+          servicePort: 80
+
+---

--- a/ingresses/staging/docs.staging.maas.io.yaml
+++ b/ingresses/staging/docs.staging.maas.io.yaml
@@ -1,0 +1,26 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: docs-staging-maas-io
+  namespace: staging
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "X-Robots-Tag: noindex";
+spec:
+  tls:
+  - secretName: docs-staging-maas-io-tls
+    hosts:
+    - docs.staging.maas.io
+  rules:
+  - host: docs.staging.maas.io
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: docs-maas-io
+          servicePort: 80
+
+---

--- a/services/docs.maas.io.yaml
+++ b/services/docs.maas.io.yaml
@@ -1,0 +1,49 @@
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: docs-maas-io
+spec:
+  selector:
+    app: docs.maas.io
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http
+
+---
+
+kind: Deployment
+apiVersion: apps/v1beta1
+metadata:
+  name: docs-maas-io
+spec:
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        app: docs.maas.io
+    spec:
+      containers:
+        - name: docs-maas-io
+          image: prod-comms.docker-registry.canonical.com/docs.maas.io:${TAG_TO_DEPLOY}
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            periodSeconds: 3
+            successThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 5
+
+---


### PR DESCRIPTION
Add config for docs.maas.io


## QA

Requires minikube and kubectl installed

```
./qa-deploy docs.maas.io
# Wait a few minutes for service to start
# Optionally run `minikube dashboard`

curl -H 'Host: docs.maas.io' `minikube ip`
# Can also add entry to /etc/hosts and test in browser