### PR TITLE
Add docs.conjure-up.io config

### DIFF
--- a/ingresses/production/docs.conjure-up.io.yaml
+++ b/ingresses/production/docs.conjure-up.io.yaml
@@ -1,0 +1,24 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: docs-conjure-up-io
+  namespace: production
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  tls:
+  - secretName: docs-conjure-up-io-tls
+    hosts:
+    - docs.conjure-up.io
+  rules:
+  - host: docs.conjure-up.io
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: docs-conjure-up-io
+          servicePort: 80
+
+---

--- a/ingresses/staging/docs.staging.conjure-up.io.yaml
+++ b/ingresses/staging/docs.staging.conjure-up.io.yaml
@@ -1,0 +1,26 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: docs-staging-conjure-up-io
+  namespace: staging
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "X-Robots-Tag: noindex";
+spec:
+  tls:
+  - secretName: docs-staging-conjure-up-io-tls
+    hosts:
+    - docs.staging.conjure-up.io
+  rules:
+  - host: docs.staging.conjure-up.io
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: docs-conjure-up-io
+          servicePort: 80
+
+---

--- a/services/docs.conjure-up.io.yaml
+++ b/services/docs.conjure-up.io.yaml
@@ -1,0 +1,49 @@
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: docs-conjure-up-io
+spec:
+  selector:
+    app: docs.conjure-up.io
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http
+
+---
+
+kind: Deployment
+apiVersion: apps/v1beta1
+metadata:
+  name: docs-conjure-up-io
+spec:
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        app: docs.conjure-up.io
+    spec:
+      containers:
+        - name: docs-conjure-up-io
+          image: prod-comms.docker-registry.canonical.com/docs.conjure-up.io:${TAG_TO_DEPLOY}
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            periodSeconds: 3
+            successThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 5
+
+---


### PR DESCRIPTION
Add config for docs.conjure-up.io


## QA

Requires minikube and kubectl installed

```
./qa-deploy docs.conjure-up.io
# Wait a few minutes for service to start
# Optionally run `minikube dashboard`

curl -H 'Host: docs.conjure-up.io' `minikube ip`
# Can also add entry to /etc/hosts and test in browser