### PR TITLE
Configs for beta.ubuntu.com

### DIFF
--- a/create-project
+++ b/create-project
@@ -6,6 +6,7 @@ from shutil import copyfile
 
 project = sys.argv[1]
 
+
 def create_service(project):
     service_file_name = 'services/%s.yaml' % project
     copyfile('templates/service.yaml', service_file_name)
@@ -14,15 +15,15 @@ def create_service(project):
 
 def create_ingresses(project, enviroments):
     project_split = project.split('.')
-    
+
     for enviroment in enviroments:
-        
+
         # Add the enviroment between the domain if subdomain
         if len(project_split) > 2:
             file_name = '%s.%s.%s.%s.yaml' % (
-                project_split[0], 
+                project_split[0],
                 enviroment,
-                project_split[1], 
+                project_split[1],
                 project_split[2]
             )
         else:
@@ -30,13 +31,13 @@ def create_ingresses(project, enviroments):
                 enviroment,
                 project
             )
-        
+
         src = 'templates/%s.yaml' % enviroment
         dst = 'ingresses/%s/%s' % (
             enviroment,
             file_name
         )
-        
+
         # Remove production from the file and project naming
         if enviroment == 'production':
             file_name = file_name.replace('production.', '')
@@ -64,4 +65,3 @@ def update_file(file_name, project):
 
 create_service(project)
 create_ingresses(project, ['staging', 'production'])
-

--- a/ingresses/production/beta.ubuntu.com.yaml
+++ b/ingresses/production/beta.ubuntu.com.yaml
@@ -1,0 +1,24 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: beta-ubuntu-com
+  namespace: production
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  tls:
+  - secretName: beta-ubuntu-com-tls
+    hosts:
+    - beta.ubuntu.com
+  rules:
+  - host: beta.ubuntu.com
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: beta-ubuntu-com
+          servicePort: 80
+
+---

--- a/ingresses/staging/beta.staging.ubuntu.com.yaml
+++ b/ingresses/staging/beta.staging.ubuntu.com.yaml
@@ -1,0 +1,26 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: beta-staging-ubuntu-com
+  namespace: staging
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "X-Robots-Tag: noindex";
+spec:
+  tls:
+  - secretName: beta-staging-ubuntu-com-tls
+    hosts:
+    - beta.staging.ubuntu.com
+  rules:
+  - host: beta.staging.ubuntu.com
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: beta-ubuntu-com
+          servicePort: 80
+
+---

--- a/services/beta.ubuntu.com.yaml
+++ b/services/beta.ubuntu.com.yaml
@@ -1,0 +1,49 @@
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: beta-ubuntu-com
+spec:
+  selector:
+    app: beta.ubuntu.com
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http
+
+---
+
+kind: Deployment
+apiVersion: apps/v1beta1
+metadata:
+  name: beta-ubuntu-com
+spec:
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        app: beta.ubuntu.com
+    spec:
+      containers:
+        - name: beta-ubuntu-com
+          image: prod-comms.docker-registry.canonical.com/beta.ubuntu.com:${TAG_TO_DEPLOY}
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            periodSeconds: 3
+            successThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 5
+
+---


### PR DESCRIPTION
QA
--

Install [latest minikube(https://github.com/kubernetes/minikube/releases)]:

``` bash
curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.25.0/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
```

Then deploy:

``` bash
# Deploy
./qa-deploy beta.ubuntu.com beta.staging.ubuntu.com

# Point the domains at minikube
echo "`minikube ip` beta.ubuntu.com beta.staging.ubuntu.com" | sudo tee -a /etc/hosts
```

Browse to http://beta.ubuntu.com and http://beta.staging.ubuntu.com, check it works.

Now delete the line from `/etc/hosts`:

``` bash
sudo sed -i "/`minikube ip` beta.ubuntu.com beta.staging.ubuntu.com/d" /etc/hosts
```
