### PR TITLE
Add --tag option; make arguments into options

### DIFF
--- a/qa-deploy
+++ b/qa-deploy
@@ -6,7 +6,7 @@ set -euo pipefail
 USAGE="Usage
 ===
 
-  $ ./qa-deploy PRODUCTION_URL [STAGING_URL]
+  $ ./qa-deploy --tag IMAGE_TAG --production PRODUCTION_URL [--staging STAGING_URL]
 
 Description
 ---
@@ -67,8 +67,9 @@ function run_minikube() {
 
 function deploy_service() {
     service="${1}"
+    tag="${2}"
 
-    cat "services/${service}.yaml" | sed 's|[:][$][{]TAG_TO_DEPLOY[_aa-zA-Z]*[}]||' | sed 's|replicas: [0-9][0-9]*|replicas: 1|' | kubectl apply --filename -
+    cat "services/${service}.yaml" | sed "s|[:][$][{]TAG_TO_DEPLOY[_aa-zA-Z]*[}]|:${tag}|" | sed 's|replicas: [0-9][0-9]*|replicas: 1|' | kubectl apply --filename -
 }
 
 function deploy_ingress() {
@@ -78,25 +79,48 @@ function deploy_ingress() {
 }
 
 function run() {
+    # Arguments
+    while [[ -n "${1:-}" ]] && [[ "${1:0:1}" == "-" ]]; do
+        key="$1"
+        case $key in
+            -t|--tag)
+                if [ -z "${2:-}" ]; then invalid "Missing image tag. Usage: --tag XXXX"; fi
+                tag_to_deploy=${2}
+                shift
+            ;;
+            -p|--production)
+                if [ -z "${2:-}" ]; then invalid "Missing production. Usage: --production XXXX"; fi
+                production=${2}
+                shift
+            ;;
+            -s|--staging)
+                if [ -z "${2:-}" ]; then invalid "Missing staging. Usage: --staging XXXX"; fi
+                staging=${2}
+                shift
+            ;;
+            *) invalid "Option '${key}' not recognised." ;;
+        esac
+        shift
+    done
+
+    # Mandatory arguments
+    if [ -z "${production:-}" ]; then invalid "No production domain specified (e.g. 'example.com')"; fi
+    if [ -z "${tag_to_deploy:-}" ]; then invalid "No image tag specified (e.g. 'latest' or 'a34dca23')"; fi
+
     echo -n "Are you connected to the VPN? [Y/n] "
     read vpn
-
     if [ "${vpn}" == "n" ]; then exit 0; fi
-
-    production="${1:-}"
-    staging="${2:-}"
-    if [ -z "${production}" ]; then invalid "Missing production url"; fi
 
     run_minikube
     add_secret_key
 
     add_docker_credentials_minikube
 
-    deploy_service "${production}"
+    deploy_service "${production}" "${tag_to_deploy}"
 
     deploy_ingress "production/${production}"
 
-    if [ -n "${staging}" ]; then deploy_ingress "staging/${staging}"; fi
+    if [ -n "${staging:-}" ]; then deploy_ingress "staging/${staging}"; fi
     apply_configuration
 }
 


### PR DESCRIPTION
Previously it's not been outwardly clear that the QA script will attempt to release an image that it expects to find at prod-comms.docker-registry.canonical.com/{project}:latest.

There is also the problem that usually in the basic flow of initially creating an image for a new service, we don't necessarily publish to the "latest" tag. It's more common to publish to a tag like "3018b561625ad213f67715d7121b15c16056e8d1-1519153583". "latest" tends to mean "the tag that is live", and usually at this stage nothing is live yet. 

Therefore I think it's much better to be declarative about requiring the user of `qa-deploy` to provide an image tag. This makes it much more clear that that tag has to exist, and for the person that ends up
copying and pasting the "./qa-deploy --production example.com --tag 3018b561625a", it's more clear what's going on if they feel like debugging any problems.

I also think, for unbounded arguments (as in ones that aren't actual script endpoints) when there is more than one arguments, option-style is much clearer - it's akin to keyword arguments. `link --from {from_location} --to {to_location}` is much clearer than `link {from_location} {to_location}`. Although if there is only one argument, this may well be unneccessary, as in `delete {file}` vs `delete --file file`, and arguments that are deliberate scripted endpoints should never use the "option" format - e.g. `minikube status`.

QA
--

``` bash
$ ./qa-deploy  # No arguments now prints usage
Error: No production domain specified (e.g. 'example.com')

Usage
===

  $ ./qa-deploy --tag SOME_TAG --production PRODUCTION_URL [--staging STAGING_URL]

Description
---
Deploy locally to minikube.
You must be connected to the Canonical VPN to use this script.

$ ./qa-deploy --production snapcraft.io  # It complains if tag is missing
Error: No image tag specified (e.g. 'latest' or 'a34dca23')
[usage instructions]

$ ./qa-deploy --tag latest --production snapcraft.io  # It works with a tag
Are you connected to the VPN? [Y/n] y
ingress was successfully enabled
Context "minikube" modified.
```