### PR TITLE
Basic deployment configs for netplan.io

### DIFF
--- a/ingresses/production/netplan.io.yaml
+++ b/ingresses/production/netplan.io.yaml
@@ -1,0 +1,24 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: netplan-io
+  namespace: production
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  tls:
+  - secretName: netplan-io-tls
+    hosts:
+    - netplan.io
+  rules:
+  - host: netplan.io
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: netplan-io
+          servicePort: 80
+
+---

--- a/ingresses/staging/staging.netplan.io.yaml
+++ b/ingresses/staging/staging.netplan.io.yaml
@@ -1,0 +1,26 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: staging-netplan-io
+  namespace: staging
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "X-Robots-Tag: noindex";
+spec:
+  tls:
+  - secretName: staging-netplan-io-tls
+    hosts:
+    - staging.netplan.io
+  rules:
+  - host: staging.netplan.io
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: netplan-io
+          servicePort: 80
+
+---

--- a/services/netplan.io.yaml
+++ b/services/netplan.io.yaml
@@ -1,0 +1,49 @@
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: netplan-io
+spec:
+  selector:
+    app: netplan.io
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http
+
+---
+
+kind: Deployment
+apiVersion: apps/v1beta1
+metadata:
+  name: netplan-io
+spec:
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        app: netplan.io
+    spec:
+      containers:
+        - name: netplan-io
+          image: prod-comms.docker-registry.canonical.com/netplan.io:${TAG_TO_DEPLOY}
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            periodSeconds: 3
+            successThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 5
+
+---


### PR DESCRIPTION
Fixes https://github.com/canonical-websites/netplan.io/issues/4

QA
--

The usual:

``` bash
$ ./qa-deploy netplan.io staging.netplan.io  # Deploy services
Are you connected to the VPN? [Y/n] 
ingress was successfully enabled
Context "minikube" modified.
service "netplan-io" unchanged
deployment "netplan-io" created
ingress "netplan-io" unchanged
ingress "staging-netplan-io" unchanged
configmap "nginx-load-balancer-conf" configured
$ echo "`minikube ip` netplan.io staging.netplan.io" | sudo tee -a /etc/hosts  # Add domain to hosts file
$ kubectl get pods --watch  # Watch pods to check it created correctly
```

Once you see "Running", visit http://netplan.io and http://staging.netplan.io and check they work.

Now remove the domains from `/etc/hosts`, and stop minikube:

``` bash
sudo sed -i "/`minikube ip` netplan.io staging.netplan.io/d" /etc/hosts
minikube stop
```