### PR TITLE
Add sentry secret

### DIFF
--- a/services/snapcraft.io.yaml
+++ b/services/snapcraft.io.yaml
@@ -44,6 +44,11 @@ spec:
                 secretKeyRef:
                   name: snapcraft-io-config
                   key: csrf_secret_key
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: snapcraft-io-config
+                  key: sentry_dsn
           readinessProbe:
             httpGet:
               path: /status


### PR DESCRIPTION
# Summary

Add sentry secret

# QA

- Create an account and a project on sentry
- `minikube start`
- `kubectl create secret generic snapcraft-io-config --from-literal=sentry_dsn=TOKEN_FROM_SENTRY --namespace default`
- `qa-deploy snapcraft.io`
- Check that the project snapcraft.io has access to the secret
- (you can check on `minikube dashboard`)
