### PR TITLE
Redirect traffic to use proxy s.io

### DIFF
--- a/services/snapcraft.io.yaml
+++ b/services/snapcraft.io.yaml
@@ -50,6 +50,10 @@ spec:
                 secretKeyRef:
                   name: snapcraft-io-config
                   key: sentry_dsn
+          envFrom:
+            - configMapRef:
+                name: proxy-config
+                optional: true
           readinessProbe:
             httpGet:
               path: /status

--- a/services/snapcraft.io.yaml
+++ b/services/snapcraft.io.yaml
@@ -25,6 +25,7 @@ spec:
     metadata:
       labels:
         app: snapcraft.io
+        useProxy: "true"
     spec:
       containers:
         - name: snapcraft-io


### PR DESCRIPTION
For s.io to use proxy

# QA

- `./qa-deploy --tag latest --production snapcraft.io`
- make sure snapcraft.io uses the proxy (has variable useProxy)