### PR TITLE
Revert "Redirect traffic to use proxy s.io" - until we work out how to use the proxy discriminately

### DIFF
--- a/services/snapcraft.io.yaml
+++ b/services/snapcraft.io.yaml
@@ -25,7 +25,6 @@ spec:
     metadata:
       labels:
         app: snapcraft.io
-        useProxy: "true"
     spec:
       containers:
         - name: snapcraft-io
@@ -50,10 +49,6 @@ spec:
                 secretKeyRef:
                   name: snapcraft-io-config
                   key: sentry_dsn
-          envFrom:
-            - configMapRef:
-                name: proxy-config
-                optional: true
           readinessProbe:
             httpGet:
               path: /status


### PR DESCRIPTION
For the time being we need to undo this, as it will break snapcraft.io if it's rolled out to production - we can't use the API through the proxy.

Reverts canonical-webteam/deployment-configs#51