### PR TITLE
Add NO_PROXY env var to proxy configmap

### DIFF
--- a/config.production.yaml
+++ b/config.production.yaml
@@ -6,6 +6,7 @@ metadata:
 data:
   HTTP_PROXY: 'http://squid.internal:3128/'
   HTTPS_PROXY: 'http://squid.internal:3128/'
+  NO_PROXY: '.snapcraft.io,.ubuntu.com,localhost'
 
 ---
 
@@ -17,6 +18,7 @@ metadata:
 data:
   HTTP_PROXY: 'http://squid.internal:3128/'
   HTTPS_PROXY: 'http://squid.internal:3128/'
+  NO_PROXY: '.snapcraft.io,.ubuntu.com,localhost'
 
 ---
 


### PR DESCRIPTION
Add whitelist domains for the NO_PROXY env var in the proxy configmap.

These domains are set to avoid using the proxy and connect directly.