### PR TITLE
Remove unused podpreset proxy configs

### DIFF
--- a/config.production.yaml
+++ b/config.production.yaml
@@ -19,33 +19,3 @@ data:
   HTTP_PROXY: 'http://squid.internal:3128/'
   HTTPS_PROXY: 'http://squid.internal:3128/'
   NO_PROXY: '.snapcraft.io,.ubuntu.com,localhost'
-
----
-
-apiVersion: settings.k8s.io/v1alpha1
-kind: PodPreset
-metadata:
-  name: global-proxy-config
-  namespace: production
-spec:
-  selector:
-    matchLabels:
-      useProxy: "true"
-  envFrom:
-    - configMapRef:
-        name: proxy-config
-
----
-
-apiVersion: settings.k8s.io/v1alpha1
-kind: PodPreset
-metadata:
-  name: global-proxy-config
-  namespace: staging
-spec:
-  selector:
-    matchLabels:
-      useProxy: "true"
-  envFrom:
-    - configMapRef:
-        name: proxy-config


### PR DESCRIPTION
The current deployed Kubernetes does not support PodPresets.
We are not using them currently and should remove them until they are
enabled.