### PR TITLE
Add all Canonical domains to NO_PROXY

### DIFF
--- a/config.production.yaml
+++ b/config.production.yaml
@@ -6,4 +6,4 @@ metadata:
 data:
   HTTP_PROXY: 'http://squid.internal:3128/'
   HTTPS_PROXY: 'http://squid.internal:3128/'
-  NO_PROXY: '.snapcraft.io,.ubuntu.com,localhost'
+  NO_PROXY: 'ubuntu.com,.ubuntu.com,snapcraft.io,.snapcraft.io,jujucharms.com,.jujucharms.com,maas.io,.maas.io,conjure-up.io,.conjure-up.io,netplan.io,.netplan.io,canonical.com,.canonical.com,launchpad.net,.launchpad.net,linuxcontainers.org,.linuxcontainers.org,cloud-init.io,.cloud-init.io,vanillaframework.io,.vanillaframework.io'

--- a/config.staging.yaml
+++ b/config.staging.yaml
@@ -6,4 +6,4 @@ metadata:
 data:
   HTTP_PROXY: 'http://squid.internal:3128/'
   HTTPS_PROXY: 'http://squid.internal:3128/'
-  NO_PROXY: '.snapcraft.io,.ubuntu.com,localhost'
+  NO_PROXY: 'ubuntu.com,.ubuntu.com,snapcraft.io,.snapcraft.io,jujucharms.com,.jujucharms.com,maas.io,.maas.io,conjure-up.io,.conjure-up.io,netplan.io,.netplan.io,canonical.com,.canonical.com,launchpad.net,.launchpad.net,linuxcontainers.org,.linuxcontainers.org,cloud-init.io,.cloud-init.io,vanillaframework.io,.vanillaframework.io'

--- a/config.staging.yaml
+++ b/config.staging.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: proxy-config
-  namespace: production
+  namespace: staging
 data:
   HTTP_PROXY: 'http://squid.internal:3128/'
   HTTPS_PROXY: 'http://squid.internal:3128/'


### PR DESCRIPTION
Any requests to Canonical-owned domains should not go through the proxy for any of our services.

Importantly, this should allow the login flow through `snapcraft.io/account` to continue to work even with the proxy enabled for other services.

QA
--

This config has been added to staging. So to verify, browse to `staging.snapcraft.io/account` with a fresh session and go through the login flow.

You can check this config exists on staging by connecting to the VPN and inspecting the staging environment:

``` bash
kubectl get configmap proxy-config --namespace staging --output yaml | less  # Inspect proxy config settings
kubectl get deployment snapcraft-io --namespace staging --output yaml | less  # Inspect snapcraft.io settings - it is using the proxy-config
```