### PR TITLE
Enable proxy for snapcraft.io - for sentry

### DIFF
--- a/services/snapcraft.io.yaml
+++ b/services/snapcraft.io.yaml
@@ -19,12 +19,15 @@ kind: Deployment
 apiVersion: apps/v1beta1
 metadata:
   name: snapcraft-io
+  labels:
+    useProxy: "true"
 spec:
   replicas: 5
   template:
     metadata:
       labels:
         app: snapcraft.io
+        useProxy: "true"
     spec:
       containers:
         - name: snapcraft-io
@@ -33,6 +36,10 @@ spec:
           ports:
             - name: http
               containerPort: 80
+          envFrom:
+            - configMapRef:
+                name: proxy-config
+                optional: true
           env:
             - name: SECRET_KEY
               valueFrom:


### PR DESCRIPTION
**This is based on #55 - review that first**

Now that the NO_PROXY setting is correctly configured (in #55), it is safe to enable to proxy in the snapcraft.io service. This will enable outbound requests to reach sentry.io for error reporting, while keeping all API requests etc. skipping the proxy.

QA
--

Ad with #55:

This config has been added to staging. So to verify, browse to `staging.snapcraft.io/account` with a fresh session and go through the login flow.

You can check this config exists on staging by connecting to the VPN and inspecting the staging environment:

``` bash
kubectl get configmap proxy-config --namespace staging --output yaml | less  # Inspect proxy config settings
kubectl get deployment snapcraft-io --namespace staging --output yaml | less  # Inspect snapcraft.io settings - it is using the proxy-config
```