### PR TITLE
Add public sentry url to snapcraft

### DIFF
--- a/services/snapcraft.io.yaml
+++ b/services/snapcraft.io.yaml
@@ -56,6 +56,11 @@ spec:
                 secretKeyRef:
                   name: snapcraft-io-config
                   key: sentry_dsn
+            - name: SENTRY_PUBLIC_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: snapcraft-io-config
+                  key: sentry_public_dsn
           readinessProbe:
             httpGet:
               path: /status


### PR DESCRIPTION
# Summary

Add public sentry dsn on s.io to get errors from frontend

# QA

- ./qa-deploy --tag latest --production snapcraft.io
- Add public sentry dsn url (ask toto for secret)
- Check secret is on snapcraft-io-config