### PR TITLE
Increase grace period for USN

### DIFF
--- a/services/usn.ubuntu.com.yaml
+++ b/services/usn.ubuntu.com.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: usn.ubuntu.com
     spec:
+      terminationGracePeriodSeconds: 120
       containers:
         - name: usn-ubuntu-com
           image: prod-comms.docker-registry.canonical.com/usn.ubuntu.com:${TAG_TO_DEPLOY}


### PR DESCRIPTION
Increase the default grace termination period for USN from 30 seconds to 120 seconds.

This is to allow downloads in progress to finish downloading before removing the pod.