### PR TITLE
Send a graceful shutdown signal to USN nginx

### DIFF
--- a/services/usn.ubuntu.com.yaml
+++ b/services/usn.ubuntu.com.yaml
@@ -34,6 +34,11 @@ spec:
           ports:
             - name: http
               containerPort: 80
+          lifecycle:
+            preStop:
+              exec:
+                # SIGTERM triggers a quick exit; gracefully terminate instead
+                command: ["/usr/sbin/nginx","-s","quit"]
           readinessProbe:
             httpGet:
               path: /


### PR DESCRIPTION
By default Kubernetes sends SIGTERM which quits nginx quickly. This adds a command to gracefully quit nginx and finish any running requests.

# QA

Deploy a test USN site: `./qa-deploy --production usn.ubuntu.com`

Delete a USN pod and it should not shut down immediatly and shutdown gracefully