### PR TITLE
Deployment configs for cn.ubuntu.com

### DIFF
--- a/ingresses/production/cn.ubuntu.com.yaml
+++ b/ingresses/production/cn.ubuntu.com.yaml
@@ -1,0 +1,24 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: cn-ubuntu-com
+  namespace: production
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  tls:
+  - secretName: cn-ubuntu-com-tls
+    hosts:
+    - cn.ubuntu.com
+  rules:
+  - host: cn.ubuntu.com
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: cn-ubuntu-com
+          servicePort: 80
+
+---

--- a/ingresses/staging/cn.staging.ubuntu.com.yaml
+++ b/ingresses/staging/cn.staging.ubuntu.com.yaml
@@ -1,0 +1,26 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: cn-staging-ubuntu-com
+  namespace: staging
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "X-Robots-Tag: noindex";
+spec:
+  tls:
+  - secretName: cn-staging-ubuntu-com-tls
+    hosts:
+    - cn.staging.ubuntu.com
+  rules:
+  - host: cn.staging.ubuntu.com
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: cn-ubuntu-com
+          servicePort: 80
+
+---

--- a/services/cn.ubuntu.com.yaml
+++ b/services/cn.ubuntu.com.yaml
@@ -1,0 +1,49 @@
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: cn-ubuntu-com
+spec:
+  selector:
+    app: cn.ubuntu.com
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http
+
+---
+
+kind: Deployment
+apiVersion: apps/v1beta1
+metadata:
+  name: cn-ubuntu-com
+spec:
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        app: cn.ubuntu.com
+    spec:
+      containers:
+        - name: cn-ubuntu-com
+          image: prod-comms.docker-registry.canonical.com/cn.ubuntu.com:${TAG_TO_DEPLOY}
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            periodSeconds: 3
+            successThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 5
+
+---


### PR DESCRIPTION
## Done
Created deployment configs for cn.ubuntu.com

## QA

Install [latest minikube](https://github.com/kubernetes/minikube/releases):

``` bash
curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.25.0/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
```

Then deploy:

``` bash
# Deploy
./qa-deploy --tag latest --production cn.ubuntu.com --staging cn.staging.ubuntu.com

# Point the domains at minikube
echo "`minikube ip` cn.ubuntu.com cn.staging.ubuntu.com" | sudo tee -a /etc/hosts
```

Browse to http://cn.ubuntu.com and http://cn.staging.ubuntu.com, check it works.

Now delete the line from `/etc/hosts`:

``` bash
sudo sed -i "/`minikube ip` cn.ubuntu.com beta.staging.ubuntu.com/d" /etc/hosts
```

Fixes #66

