### PR TITLE
Add canonical deployment config

### DIFF
--- a/ingresses/production/canonical.com.yaml
+++ b/ingresses/production/canonical.com.yaml
@@ -1,0 +1,28 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: canonical-com
+  namespace: production
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    ingress.kubernetes.io/configuration-snippet: |
+      if ($host = 'www.canonical.com' ) {
+        rewrite ^ https://canonical.com$request_uri permanent;
+      }
+spec:
+  tls:
+  - secretName: canonical-com-tls
+    hosts:
+    - canonical.com
+  rules:
+  - host: canonical.com
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: canonical-com
+          servicePort: 80
+
+---

--- a/ingresses/staging/staging.canonical.com.yaml
+++ b/ingresses/staging/staging.canonical.com.yaml
@@ -1,0 +1,26 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: staging-canonical-com
+  namespace: staging
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "X-Robots-Tag: noindex";
+spec:
+  tls:
+  - secretName: staging-canonical-com-tls
+    hosts:
+    - staging.canonical.com
+  rules:
+  - host: staging.canonical.com
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: canonical-com
+          servicePort: 80
+
+---

--- a/services/canonical.com.yaml
+++ b/services/canonical.com.yaml
@@ -1,0 +1,49 @@
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: canonical-com
+spec:
+  selector:
+    app: canonical.com
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http
+
+---
+
+kind: Deployment
+apiVersion: apps/v1beta1
+metadata:
+  name: canonical-com
+spec:
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        app: canonical.com
+    spec:
+      containers:
+        - name: canonical-com
+          image: prod-comms.docker-registry.canonical.com/canonical.com:${TAG_TO_DEPLOY}
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            periodSeconds: 3
+            successThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 5
+
+---


### PR DESCRIPTION
# Summary

Add www.canonical.com dep config

# QA

-  `./qa-deploy --tag latest --production canonical.com`
- Modify your `/etc/host` to point this domain to minikube's URL
- Access canonical.com , check if the website works as usual
- Access www.canonical.com you should be redirected to canonical.com