### PR TITLE
Add cloud-init.io deployment configs

### DIFF
--- a/ingresses/production/cloud-init.io.yaml
+++ b/ingresses/production/cloud-init.io.yaml
@@ -1,0 +1,24 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: cloud-init-io
+  namespace: production
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  tls:
+  - secretName: cloud-init-io-tls
+    hosts:
+    - cloud-init.io
+  rules:
+  - host: cloud-init.io
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: cloud-init-io
+          servicePort: 80
+
+---

--- a/ingresses/staging/staging.cloud-init.io.yaml
+++ b/ingresses/staging/staging.cloud-init.io.yaml
@@ -1,0 +1,26 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: staging-cloud-init-io
+  namespace: staging
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "X-Robots-Tag: noindex";
+spec:
+  tls:
+  - secretName: staging-cloud-init-io-tls
+    hosts:
+    - staging.cloud-init.io
+  rules:
+  - host: staging.cloud-init.io
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: cloud-init-io
+          servicePort: 80
+
+---

--- a/services/cloud-init.io.yaml
+++ b/services/cloud-init.io.yaml
@@ -1,0 +1,49 @@
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: cloud-init-io
+spec:
+  selector:
+    app: cloud-init.io
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http
+
+---
+
+kind: Deployment
+apiVersion: apps/v1beta1
+metadata:
+  name: cloud-init-io
+spec:
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        app: cloud-init.io
+    spec:
+      containers:
+        - name: cloud-init-io
+          image: prod-comms.docker-registry.canonical.com/cloud-init.io:${TAG_TO_DEPLOY}
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            periodSeconds: 3
+            successThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 5
+
+---


### PR DESCRIPTION
## Done
Created deployment configs for cloud-init.io

## QA

Install [latest minikube](https://github.com/kubernetes/minikube/releases):

``` bash
curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.25.0/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
```

Then deploy:

``` bash
# Deploy
./qa-deploy --tag latest --production cloud-init.io --staging staging.cloud-init.io

# Point the domains at minikube
echo "`minikube ip` cloud-init.io staging.cloud-init.io" | sudo tee -a /etc/hosts
```

Browse to http://cloud-init.io and http://staging.cloud-init.io, check it works.

Now delete the line from `/etc/hosts`:

``` bash
sudo sed -i "/`minikube ip` cloud-init.io staging.cloud-init.io/" /etc/hosts
```