### PR TITLE
Add conjure-up.io deployment config

### DIFF
--- a/ingresses/production/conjure-up.io.yaml
+++ b/ingresses/production/conjure-up.io.yaml
@@ -1,0 +1,24 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: conjure-up-io
+  namespace: production
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  tls:
+  - secretName: conjure-up-io-tls
+    hosts:
+    - conjure-up.io
+  rules:
+  - host: conjure-up.io
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: conjure-up-io
+          servicePort: 80
+
+---

--- a/ingresses/staging/staging.conjure-up.io.yaml
+++ b/ingresses/staging/staging.conjure-up.io.yaml
@@ -1,0 +1,26 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: staging-conjure-up-io
+  namespace: staging
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "X-Robots-Tag: noindex";
+spec:
+  tls:
+  - secretName: staging-conjure-up-io-tls
+    hosts:
+    - staging.conjure-up.io
+  rules:
+  - host: staging.conjure-up.io
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: conjure-up-io
+          servicePort: 80
+
+---

--- a/services/conjure-up.io.yaml
+++ b/services/conjure-up.io.yaml
@@ -1,0 +1,49 @@
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: conjure-up-io
+spec:
+  selector:
+    app: conjure-up.io
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http
+
+---
+
+kind: Deployment
+apiVersion: apps/v1beta1
+metadata:
+  name: conjure-up-io
+spec:
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        app: conjure-up.io
+    spec:
+      containers:
+        - name: conjure-up-io
+          image: prod-comms.docker-registry.canonical.com/conjure-up.io:${TAG_TO_DEPLOY}
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            periodSeconds: 3
+            successThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 5
+
+---


### PR DESCRIPTION
## Done
Created deployment configs for conjure-up.io

## QA

Install [latest minikube](https://github.com/kubernetes/minikube/releases):

``` bash
curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.25.0/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
```

Then deploy:

``` bash
# Deploy
./qa-deploy --tag latest --production conjure-up.io --staging staging.conjure-up.io

# Point the domains at minikube
echo "`minikube ip` conjure-up.io staging.conjure-up.io" | sudo tee -a /etc/hosts
```

Browse to http://conjure-up.io and http://staging.conjure-up.io, check it works.

Now delete the line from `/etc/hosts`:

``` bash
sudo sed -i "/`minikube ip` conjure-up.io staging.conjure-up.io/" /etc/hosts
```