### PR TITLE
Reset the imagePullPolicy to use the default

### DIFF
--- a/services/beta.ubuntu.com.yaml
+++ b/services/beta.ubuntu.com.yaml
@@ -29,7 +29,6 @@ spec:
       containers:
         - name: beta-ubuntu-com
           image: prod-comms.docker-registry.canonical.com/beta.ubuntu.com:${TAG_TO_DEPLOY}
-          imagePullPolicy: Always
           ports:
             - name: http
               containerPort: 80

--- a/services/canonical.com.yaml
+++ b/services/canonical.com.yaml
@@ -29,7 +29,6 @@ spec:
       containers:
         - name: canonical-com
           image: prod-comms.docker-registry.canonical.com/canonical.com:${TAG_TO_DEPLOY}
-          imagePullPolicy: Always
           ports:
             - name: http
               containerPort: 80

--- a/services/cloud-init.io.yaml
+++ b/services/cloud-init.io.yaml
@@ -29,7 +29,6 @@ spec:
       containers:
         - name: cloud-init-io
           image: prod-comms.docker-registry.canonical.com/cloud-init.io:${TAG_TO_DEPLOY}
-          imagePullPolicy: Always
           ports:
             - name: http
               containerPort: 80

--- a/services/cn.ubuntu.com.yaml
+++ b/services/cn.ubuntu.com.yaml
@@ -29,7 +29,6 @@ spec:
       containers:
         - name: cn-ubuntu-com
           image: prod-comms.docker-registry.canonical.com/cn.ubuntu.com:${TAG_TO_DEPLOY}
-          imagePullPolicy: Always
           ports:
             - name: http
               containerPort: 80

--- a/services/conjure-up.io.yaml
+++ b/services/conjure-up.io.yaml
@@ -29,7 +29,6 @@ spec:
       containers:
         - name: conjure-up-io
           image: prod-comms.docker-registry.canonical.com/conjure-up.io:${TAG_TO_DEPLOY}
-          imagePullPolicy: Always
           ports:
             - name: http
               containerPort: 80

--- a/services/design.ubuntu.com.yaml
+++ b/services/design.ubuntu.com.yaml
@@ -29,7 +29,6 @@ spec:
       containers:
         - name: design-ubuntu-com
           image: prod-comms.docker-registry.canonical.com/design.ubuntu.com:${TAG_TO_DEPLOY}
-          imagePullPolicy: Always
           ports:
             - name: http
               containerPort: 80

--- a/services/docs.conjure-up.io.yaml
+++ b/services/docs.conjure-up.io.yaml
@@ -29,7 +29,6 @@ spec:
       containers:
         - name: docs-conjure-up-io
           image: prod-comms.docker-registry.canonical.com/docs.conjure-up.io:${TAG_TO_DEPLOY}
-          imagePullPolicy: Always
           ports:
             - name: http
               containerPort: 80

--- a/services/docs.maas.io.yaml
+++ b/services/docs.maas.io.yaml
@@ -29,7 +29,6 @@ spec:
       containers:
         - name: docs-maas-io
           image: prod-comms.docker-registry.canonical.com/docs.maas.io:${TAG_TO_DEPLOY}
-          imagePullPolicy: Always
           ports:
             - name: http
               containerPort: 80

--- a/services/docs.snapcraft.io.yaml
+++ b/services/docs.snapcraft.io.yaml
@@ -30,7 +30,6 @@ spec:
       containers:
         - name: docs-snapcraft-io
           image: prod-comms.docker-registry.canonical.com/docs.snapcraft.io:${TAG_TO_DEPLOY}
-          imagePullPolicy: Always
           ports:
             - name: http
               containerPort: 80

--- a/services/docs.ubuntu.com.yaml
+++ b/services/docs.ubuntu.com.yaml
@@ -59,7 +59,6 @@ spec:
       containers:
         - name: docs-ubuntu-com
           image: prod-comms.docker-registry.canonical.com/docs.ubuntu.com:${TAG_TO_DEPLOY}
-          imagePullPolicy: Always
           ports:
             - name: http
               containerPort: 80
@@ -92,7 +91,6 @@ spec:
       containers:
         - name: docs-ubuntu-com-core
           image: prod-comms.docker-registry.canonical.com/docs.ubuntu.com-core:${TAG_TO_DEPLOY_CORE}
-          imagePullPolicy: Always
           ports:
             - name: http
               containerPort: 80
@@ -125,7 +123,6 @@ spec:
       containers:
         - name: docs-ubuntu-com-phone
           image: prod-comms.docker-registry.canonical.com/docs.ubuntu.com-phone:${TAG_TO_DEPLOY_PHONE}
-          imagePullPolicy: Always
           ports:
             - name: http
               containerPort: 80

--- a/services/docs.vanillaframework.io.yaml
+++ b/services/docs.vanillaframework.io.yaml
@@ -29,7 +29,6 @@ spec:
       containers:
         - name: docs-vanillaframework-io
           image: prod-comms.docker-registry.canonical.com/docs.vanillaframework.io:${TAG_TO_DEPLOY}
-          imagePullPolicy: Always
           ports:
             - name: http
               containerPort: 80

--- a/services/insights.ubuntu.com.yaml
+++ b/services/insights.ubuntu.com.yaml
@@ -32,7 +32,6 @@ spec:
       containers:
         - name: insights-ubuntu-com
           image: prod-comms.docker-registry.canonical.com/insights.ubuntu.com:${TAG_TO_DEPLOY}
-          imagePullPolicy: Always
           ports:
             - name: http
               containerPort: 80

--- a/services/jp.ubuntu.com.yaml
+++ b/services/jp.ubuntu.com.yaml
@@ -29,7 +29,6 @@ spec:
       containers:
         - name: jp-ubuntu-com
           image: prod-comms.docker-registry.canonical.com/jp.ubuntu.com:${TAG_TO_DEPLOY}
-          imagePullPolicy: Always
           ports:
             - name: http
               containerPort: 80

--- a/services/netplan.io.yaml
+++ b/services/netplan.io.yaml
@@ -29,7 +29,6 @@ spec:
       containers:
         - name: netplan-io
           image: prod-comms.docker-registry.canonical.com/netplan.io:${TAG_TO_DEPLOY}
-          imagePullPolicy: Always
           ports:
             - name: http
               containerPort: 80

--- a/services/snapcraft.io.yaml
+++ b/services/snapcraft.io.yaml
@@ -32,7 +32,6 @@ spec:
       containers:
         - name: snapcraft-io
           image: prod-comms.docker-registry.canonical.com/snapcraft.io:${TAG_TO_DEPLOY}
-          imagePullPolicy: Always
           ports:
             - name: http
               containerPort: 80

--- a/services/tutorials.ubuntu.com.yaml
+++ b/services/tutorials.ubuntu.com.yaml
@@ -29,7 +29,6 @@ spec:
       containers:
         - name: tutorials-ubuntu-com
           image: prod-comms.docker-registry.canonical.com/tutorials.ubuntu.com:${TAG_TO_DEPLOY}
-          imagePullPolicy: Always
           ports:
             - name: http
               containerPort: 80

--- a/services/usn.ubuntu.com.yaml
+++ b/services/usn.ubuntu.com.yaml
@@ -30,7 +30,6 @@ spec:
       containers:
         - name: usn-ubuntu-com
           image: prod-comms.docker-registry.canonical.com/usn.ubuntu.com:${TAG_TO_DEPLOY}
-          imagePullPolicy: Always
           ports:
             - name: http
               containerPort: 80

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -29,7 +29,6 @@ spec:
       containers:
         - name: PROJECTNAME
           image: prod-comms.docker-registry.canonical.com/PROJECTDOMAIN:${TAG_TO_DEPLOY}
-          imagePullPolicy: Always
           ports:
             - name: http
               containerPort: 80


### PR DESCRIPTION
We initially set this pull policy to "Always" so that we could do "kubectl set image xxxx" with the *same* commit ID as the image tag and still trigger a roll-out.

However, now we add timestamps to the image names, meaning we can trigger rollouts whenever we need just by pushing an image with a new timestamp, so this is no long an issue.

We've now had a few outages when Kubernetes can't communicate with the registry. "imagePullPolicy: Always" would certainly exacerbate these problems, because it prevents kubernetes from using a local image if one exists.

Since I don't think we need imagePullPolicy: Always any more, I'm removing all "imagePullPolicy: Always" configuration, so it will use the default of "IfNotPresent".