### PR TITLE
Add manager.assets.ubuntu.com

### DIFF
--- a/ingresses/production/manager.assets.ubuntu.com.yaml
+++ b/ingresses/production/manager.assets.ubuntu.com.yaml
@@ -1,0 +1,24 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: manager-assets-ubuntu-com
+  namespace: production
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  tls:
+  - secretName: manager-assets-ubuntu-com-tls
+    hosts:
+    - manager.assets.ubuntu.com
+  rules:
+  - host: manager.assets.ubuntu.com
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: manager-assets-ubuntu-com
+          servicePort: 80
+
+---

--- a/ingresses/staging/manager.assets.staging.ubuntu.com.yaml
+++ b/ingresses/staging/manager.assets.staging.ubuntu.com.yaml
@@ -1,0 +1,26 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: manager-assets-staging-ubuntu-com
+  namespace: staging
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "X-Robots-Tag: noindex";
+spec:
+  tls:
+  - secretName: manager-assets-staging-ubuntu-com-tls
+    hosts:
+    - manager.assets.staging.ubuntu.com
+  rules:
+  - host: manager.assets.staging.ubuntu.com
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: manager-assets-ubuntu-com
+          servicePort: 80
+
+---

--- a/services/manager.assets.ubuntu.com.yaml
+++ b/services/manager.assets.ubuntu.com.yaml
@@ -1,0 +1,55 @@
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: manager-assets-ubuntu-com
+spec:
+  selector:
+    app: manager.assets.ubuntu.com
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http
+
+---
+
+kind: Deployment
+apiVersion: apps/v1beta1
+metadata:
+  name: manager-assets-ubuntu-com
+spec:
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        app: manager.assets.ubuntu.com
+    spec:
+      containers:
+        - name: manager-assets-ubuntu-com
+          image: prod-comms.docker-registry.canonical.com/manager.assets.ubuntu.com:${TAG_TO_DEPLOY}
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 80
+          env:
+            - name: WEBSERVICE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: manager-assets-ubuntu-com-config
+                  key: WEBSERVICE_URL
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            periodSeconds: 3
+            successThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 5
+
+---


### PR DESCRIPTION
# WIP: Image not ready


Add manager.assets.ubuntu.com config, including environment variable referenced from secret.


## QA

Install [latest minikube](https://github.com/kubernetes/minikube/releases):

``` bash
curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.25.0/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
```

Then deploy:

``` bash
# Deploy
./qa-deploy --tag latest --production manager.assets.ubuntu.com --staging manager.assets.staging.ubuntu.com

# Point the domains at minikube
echo "`minikube ip` manager.assets.ubuntu.com manager.assets.staging.ubuntu.com" | sudo tee -a /etc/hosts
```

Browse to http://manager.assets.ubuntu.com and http://manager.assets.staging.ubuntu.com, check it works.

Now delete the line from `/etc/hosts`:

``` bash
sudo sed -i "/`minikube ip` manager.assets.ubuntu.com manager.assets.staging.ubuntu.com/" /etc/hosts
```