### PR TITLE
Give snapcraft.io 9 replicas

### DIFF
--- a/services/snapcraft.io.yaml
+++ b/services/snapcraft.io.yaml
@@ -22,7 +22,7 @@ metadata:
   labels:
     useProxy: "true"
 spec:
-  replicas: 5
+  replicas: 9
   template:
     metadata:
       labels:


### PR DESCRIPTION
We're still getting restarts and reliability problems in snapcraft.io. We're working on a number of mitigations for this, but until it's much more stable I'd like to up the number of replicas to 9