### PR TITLE
9 repliaces for usn.ubuntu.com

### DIFF
--- a/services/usn.ubuntu.com.yaml
+++ b/services/usn.ubuntu.com.yaml
@@ -20,7 +20,7 @@ apiVersion: apps/v1beta1
 metadata:
   name: usn-ubuntu-com
 spec:
-  replicas: 5
+  replicas: 9
   template:
     metadata:
       labels:


### PR DESCRIPTION
Until we've got squid in front of usn.ubuntu.com, I'd like to up the number of replicas to 9 to help with the Landscape database downloading timeouts.