### PR TITLE
More replicas for insights.ubuntu.com

### DIFF
--- a/services/insights.ubuntu.com.yaml
+++ b/services/insights.ubuntu.com.yaml
@@ -22,7 +22,7 @@ metadata:
   labels:
     useProxy: "true"
 spec:
-  replicas: 5
+  replicas: 9
   template:
     metadata:
       labels:


### PR DESCRIPTION
insights.ubuntu.com is high-traffic. Until we have effective caching, let's up the number of replicas (as for snapcraft.io and usn.ubuntu.com).