### PR TITLE
Point cn.ubuntu.com healthcheck at /_status/ping

### DIFF
--- a/services/cn.ubuntu.com.yaml
+++ b/services/cn.ubuntu.com.yaml
@@ -34,15 +34,17 @@ spec:
               containerPort: 80
           readinessProbe:
             httpGet:
-              path: /
+              path: /_status/ping
               port: 80
             periodSeconds: 3
             successThreshold: 3
+            timeoutSeconds: 3
           livenessProbe:
             httpGet:
-              path: /
+              path: /_status/ping
               port: 80
             initialDelaySeconds: 5
             periodSeconds: 5
+            timeoutSeconds: 3
 
 ---


### PR DESCRIPTION
Update the healthcheck to use the Talisker endpoint and increase the timeouts to 3 seconds (from the default of 1 second) to account for temporary slowdowns.