### PR TITLE
Fix environement from configMaps

### DIFF
--- a/services/snapcraft.io.yaml
+++ b/services/snapcraft.io.yaml
@@ -39,10 +39,12 @@ spec:
             - configMapRef:
                 name: proxy-config
                 optional: true
-            - configMapRef:
-                name: global-config
-                optional: true
           env:
+            - name: ENVIRONMENT
+              valueFrom:
+                configMapKeyRef:
+                  name: global-config
+                  key: environment
             - name: SECRET_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
# Summary

The enviroment var wasn't getted by the deployement under the tag `envFrom`. By moving it to the tag `env` it fixes the problem

# QA

- `./qa-deploy --tag latest --production snapcraft.io`
- create file `file.yaml`:
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: global-config
data:
  environment: "toto"
```
- `kubectl apply -f file.yaml`
- Make sure snapcraft.io pod uses the var ENVIRONMENT=toto