### PR TITLE
Configs for docs.jujucharms.com

### DIFF
--- a/ingresses/production/docs.jujucharms.com.yaml
+++ b/ingresses/production/docs.jujucharms.com.yaml
@@ -1,0 +1,24 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: docs-jujucharms-com
+  namespace: production
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  tls:
+  - secretName: docs-jujucharms-com-tls
+    hosts:
+    - docs.jujucharms.com
+  rules:
+  - host: docs.jujucharms.com
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: docs-jujucharms-com
+          servicePort: 80
+
+---

--- a/ingresses/staging/docs.staging.jujucharms.com.yaml
+++ b/ingresses/staging/docs.staging.jujucharms.com.yaml
@@ -1,0 +1,26 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: docs-staging-jujucharms-com
+  namespace: staging
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "X-Robots-Tag: noindex";
+spec:
+  tls:
+  - secretName: docs-staging-jujucharms-com-tls
+    hosts:
+    - docs.staging.jujucharms.com
+  rules:
+  - host: docs.staging.jujucharms.com
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: docs-jujucharms-com
+          servicePort: 80
+
+---

--- a/services/docs.jujucharms.com.yaml
+++ b/services/docs.jujucharms.com.yaml
@@ -1,0 +1,48 @@
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: docs-jujucharms-com
+spec:
+  selector:
+    app: docs.jujucharms.com
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http
+
+---
+
+kind: Deployment
+apiVersion: apps/v1beta1
+metadata:
+  name: docs-jujucharms-com
+spec:
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        app: docs.jujucharms.com
+    spec:
+      containers:
+        - name: docs-jujucharms-com
+          image: prod-comms.docker-registry.canonical.com/docs.jujucharms.com:${TAG_TO_DEPLOY}
+          ports:
+            - name: http
+              containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            periodSeconds: 3
+            successThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 5
+
+---


### PR DESCRIPTION
## Done
Created deployment configs for docs.jujucharms.com

## QA

Install [latest minikube](https://github.com/kubernetes/minikube/releases):

``` bash
curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.25.0/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
```

Then deploy:

``` bash
# Deploy
./qa-deploy --tag latest --production docs.jujucharms.com --staging docs.staging.jujucharms.com

# Point the domains at minikube
echo "`minikube ip` docs.jujucharms.com docs.staging.jujucharms.com" | sudo tee -a /etc/hosts
```

Browse to docs.jujucharms.com and http://docs.staging.jujucharms.com, check it works.

Now delete the line from `/etc/hosts`:

``` bash
sudo sed -i "/`minikube ip` docs.jujucharms.com docs.staging.jujucharms.com/" /etc/hosts
```