### PR TITLE
Add Developer domain redirects

### DIFF
--- a/ingresses/production/developer.ubuntu.com.yaml
+++ b/ingresses/production/developer.ubuntu.com.yaml
@@ -7,13 +7,33 @@ metadata:
   namespace: production
   annotations:
     kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      if ($host ~ ^(dev|developers)\.ubuntu\.com$ ) {
+        rewrite ^ https://developer.ubuntu.com$request_uri permanent;
+      }
 spec:
   tls:
   - secretName: developer-ubuntu-com-tls
     hosts:
     - developer.ubuntu.com
+    - developers.ubuntu.com
+    - dev.ubuntu.com
   rules:
   - host: developer.ubuntu.com
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: developer-ubuntu-com
+          servicePort: 80
+  - host: developers.ubuntu.com
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: developer-ubuntu-com
+          servicePort: 80
+  - host: dev.ubuntu.com
     http:
       paths:
       - path: /


### PR DESCRIPTION
Add redirects for extra developer.ubuntu.com domains, back to the canonical domain.

# QA

`./qa-deploy --tag latest --production developer.ubuntu.com`
Wait for it to go up

The domains should redirect correctly:
- `curl -I $(minikube ip) -H "Host:dev.ubuntu.com"`
- `curl -I $(minikube ip) -H "Host:developers.ubuntu.com"`