### PR TITLE
Update Nginx Ingress annotation name

### DIFF
--- a/ingresses/production/canonical.com.yaml
+++ b/ingresses/production/canonical.com.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: production
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    ingress.kubernetes.io/configuration-snippet: |
+    nginx.ingress.kubernetes.io/configuration-snippet: |
       if ($host = 'www.canonical.com' ) {
         rewrite ^ https://canonical.com$request_uri permanent;
       }

--- a/ingresses/production/cloud-init.io.yaml
+++ b/ingresses/production/cloud-init.io.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: production
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    ingress.kubernetes.io/configuration-snippet: |
+    nginx.ingress.kubernetes.io/configuration-snippet: |
       if ($host = 'www.cloud-init.io' ) {
         rewrite ^ https://cloud-init.io$request_uri permanent;
       }

--- a/ingresses/production/conjure-up.io.yaml
+++ b/ingresses/production/conjure-up.io.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: production
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    ingress.kubernetes.io/configuration-snippet: |
+    nginx.ingress.kubernetes.io/configuration-snippet: |
       if ($host = 'www.conjure-up.io' ) {
         rewrite ^ https://conjure-up.io$request_uri permanent;
       }

--- a/ingresses/production/maas.io.yaml
+++ b/ingresses/production/maas.io.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: production
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    ingress.kubernetes.io/configuration-snippet: |
+    nginx.ingress.kubernetes.io/configuration-snippet: |
       if ($host = 'www.maas.io' ) {
         rewrite ^ https://maas.io$request_uri permanent;
       }

--- a/ingresses/production/snapcraft.io.yaml
+++ b/ingresses/production/snapcraft.io.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: production
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    ingress.kubernetes.io/configuration-snippet: |
+    nginx.ingress.kubernetes.io/configuration-snippet: |
       if ($host = 'www.snapcraft.io' ) {
         rewrite ^ https://snapcraft.io$request_uri permanent;
       }

--- a/ingresses/staging/beta.staging.ubuntu.com.yaml
+++ b/ingresses/staging/beta.staging.ubuntu.com.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: staging
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    ingress.kubernetes.io/configuration-snippet: |
+    nginx.ingress.kubernetes.io/configuration-snippet: |
       more_set_headers "X-Robots-Tag: noindex";
 spec:
   tls:

--- a/ingresses/staging/cn.staging.ubuntu.com.yaml
+++ b/ingresses/staging/cn.staging.ubuntu.com.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: staging
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    ingress.kubernetes.io/configuration-snippet: |
+    nginx.ingress.kubernetes.io/configuration-snippet: |
       more_set_headers "X-Robots-Tag: noindex";
 spec:
   tls:

--- a/ingresses/staging/design.staging.ubuntu.com.yaml
+++ b/ingresses/staging/design.staging.ubuntu.com.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: staging
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    ingress.kubernetes.io/configuration-snippet: |
+    nginx.ingress.kubernetes.io/configuration-snippet: |
       more_set_headers "X-Robots-Tag: noindex";
 spec:
   tls:

--- a/ingresses/staging/developer.staging.ubuntu.com.yaml
+++ b/ingresses/staging/developer.staging.ubuntu.com.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: staging
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    ingress.kubernetes.io/configuration-snippet: |
+    nginx.ingress.kubernetes.io/configuration-snippet: |
       more_set_headers "X-Robots-Tag: noindex";
 spec:
   tls:

--- a/ingresses/staging/docs.staging.conjure-up.io.yaml
+++ b/ingresses/staging/docs.staging.conjure-up.io.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: staging
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    ingress.kubernetes.io/configuration-snippet: |
+    nginx.ingress.kubernetes.io/configuration-snippet: |
       more_set_headers "X-Robots-Tag: noindex";
 spec:
   tls:

--- a/ingresses/staging/docs.staging.jujucharms.com.yaml
+++ b/ingresses/staging/docs.staging.jujucharms.com.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: staging
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    ingress.kubernetes.io/configuration-snippet: |
+    nginx.ingress.kubernetes.io/configuration-snippet: |
       more_set_headers "X-Robots-Tag: noindex";
 spec:
   tls:

--- a/ingresses/staging/docs.staging.maas.io.yaml
+++ b/ingresses/staging/docs.staging.maas.io.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: staging
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    ingress.kubernetes.io/configuration-snippet: |
+    nginx.ingress.kubernetes.io/configuration-snippet: |
       more_set_headers "X-Robots-Tag: noindex";
 spec:
   tls:

--- a/ingresses/staging/docs.staging.snapcraft.io.yaml
+++ b/ingresses/staging/docs.staging.snapcraft.io.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: staging
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    ingress.kubernetes.io/configuration-snippet: |
+    nginx.ingress.kubernetes.io/configuration-snippet: |
       more_set_headers "X-Robots-Tag: noindex";
 spec:
   tls:

--- a/ingresses/staging/docs.staging.ubuntu.com.yaml
+++ b/ingresses/staging/docs.staging.ubuntu.com.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: staging
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    ingress.kubernetes.io/configuration-snippet: |
+    nginx.ingress.kubernetes.io/configuration-snippet: |
       more_set_headers "X-Robots-Tag: noindex";
 spec:
   tls:

--- a/ingresses/staging/docs.staging.vanillaframework.io.yaml
+++ b/ingresses/staging/docs.staging.vanillaframework.io.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: staging
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    ingress.kubernetes.io/configuration-snippet: |
+    nginx.ingress.kubernetes.io/configuration-snippet: |
       more_set_headers "X-Robots-Tag: noindex";
 spec:
   tls:

--- a/ingresses/staging/insights.staging.ubuntu.com.yaml
+++ b/ingresses/staging/insights.staging.ubuntu.com.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: staging
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    ingress.kubernetes.io/configuration-snippet: |
+    nginx.ingress.kubernetes.io/configuration-snippet: |
       more_set_headers "X-Robots-Tag: noindex";
 spec:
   tls:

--- a/ingresses/staging/jp.staging.ubuntu.com.yaml
+++ b/ingresses/staging/jp.staging.ubuntu.com.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: staging
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    ingress.kubernetes.io/configuration-snippet: |
+    nginx.ingress.kubernetes.io/configuration-snippet: |
       more_set_headers "X-Robots-Tag: noindex";
 spec:
   tls:

--- a/ingresses/staging/staging.canonical.com.yaml
+++ b/ingresses/staging/staging.canonical.com.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: staging
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    ingress.kubernetes.io/configuration-snippet: |
+    nginx.ingress.kubernetes.io/configuration-snippet: |
       more_set_headers "X-Robots-Tag: noindex";
 spec:
   tls:

--- a/ingresses/staging/staging.cloud-init.io.yaml
+++ b/ingresses/staging/staging.cloud-init.io.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: staging
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    ingress.kubernetes.io/configuration-snippet: |
+    nginx.ingress.kubernetes.io/configuration-snippet: |
       more_set_headers "X-Robots-Tag: noindex";
 spec:
   tls:

--- a/ingresses/staging/staging.conjure-up.io.yaml
+++ b/ingresses/staging/staging.conjure-up.io.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: staging
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    ingress.kubernetes.io/configuration-snippet: |
+    nginx.ingress.kubernetes.io/configuration-snippet: |
       more_set_headers "X-Robots-Tag: noindex";
 spec:
   tls:

--- a/ingresses/staging/staging.maas.io.yaml
+++ b/ingresses/staging/staging.maas.io.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: staging
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    ingress.kubernetes.io/configuration-snippet: |
+    nginx.ingress.kubernetes.io/configuration-snippet: |
       more_set_headers "X-Robots-Tag: noindex";
 spec:
   tls:

--- a/ingresses/staging/staging.netplan.io.yaml
+++ b/ingresses/staging/staging.netplan.io.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: staging
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    ingress.kubernetes.io/configuration-snippet: |
+    nginx.ingress.kubernetes.io/configuration-snippet: |
       more_set_headers "X-Robots-Tag: noindex";
 spec:
   tls:

--- a/ingresses/staging/staging.snapcraft.io.yaml
+++ b/ingresses/staging/staging.snapcraft.io.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: staging
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    ingress.kubernetes.io/configuration-snippet: |
+    nginx.ingress.kubernetes.io/configuration-snippet: |
       more_set_headers "X-Robots-Tag: noindex";
 spec:
   tls:

--- a/ingresses/staging/tutorials.staging.ubuntu.com.yaml
+++ b/ingresses/staging/tutorials.staging.ubuntu.com.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: staging
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    ingress.kubernetes.io/configuration-snippet: |
+    nginx.ingress.kubernetes.io/configuration-snippet: |
       more_set_headers "X-Robots-Tag: noindex";
 spec:
   tls:

--- a/ingresses/staging/usn.staging.ubuntu.com.yaml
+++ b/ingresses/staging/usn.staging.ubuntu.com.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: staging
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    ingress.kubernetes.io/configuration-snippet: |
+    nginx.ingress.kubernetes.io/configuration-snippet: |
       more_set_headers "X-Robots-Tag: noindex";
 spec:
   tls:

--- a/templates/staging.yaml
+++ b/templates/staging.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: staging
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    ingress.kubernetes.io/configuration-snippet: |
+    nginx.ingress.kubernetes.io/configuration-snippet: |
       more_set_headers "X-Robots-Tag: noindex";
 spec:
   tls:


### PR DESCRIPTION
Rename annotation names for Nginx configuration snippets.
This is the same as developer.ubuntu.com configuration created in PR #126 

The annotation changed in: https://github.com/kubernetes/ingress-nginx/releases/tag/nginx-0.9.0

## QA

Steps to test cloud-init.io as an example:
```
./qa-deploy --tag latest --production cloud-init.io
curl -IH 'Host: www.cloud-init.io' `minikube ip` | grep "Location: https://cloud-init.io/"
```