### PR TITLE
Redirect to blog using https

### DIFF
--- a/ingresses/production/insights.ubuntu.com.yaml
+++ b/ingresses/production/insights.ubuntu.com.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/configuration-snippet:
-      rewrite ^ http://blog.ubuntu.com$request_uri permanent;
+      rewrite ^ https://blog.ubuntu.com$request_uri? permanent;
 spec:
   tls:
   - secretName: insights-ubuntu-com-tls

--- a/ingresses/staging/insights.staging.ubuntu.com.yaml
+++ b/ingresses/staging/insights.staging.ubuntu.com.yaml
@@ -9,7 +9,7 @@ metadata:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       more_set_headers "X-Robots-Tag: noindex";
-      rewrite ^ http://blog.staging.ubuntu.com$request_uri permanent;
+      rewrite ^ https://blog.staging.ubuntu.com$request_uri? permanent;
 spec:
   tls:
   - secretName: insights-staging-ubuntu-com-tls


### PR DESCRIPTION
Now that TLS certs for blog.{staging.}ubuntu.com are set up properly, we
should redirect directly to HTTPS, rather than doing the extra step
through HTTP.

Also, make query parameters redirect properly.

Fixes https://github.com/canonical-websites/blog.ubuntu.com/issues/359

QA
--

``` bash
$ sed -i '/namespace:/d' ingresses/production/insights.ubuntu.com.yaml ingresses/staging/insights.staging.ubuntu.com.yaml  # Remove namespaces from ingresses
$ minikube start  # Start your minikube  # Start minikube
$ kubectl config use-context minikube  # Make sure
$ kubectl apply -f ingresses/production/insights.ubuntu.com.yaml  # Apply ingress
$ kubectl apply -f ingresses/staging/insights.staging.ubuntu.com.yaml  # Apply ingress
$ curl -sI "https://insights.ubuntu.com/?fish=chips" | grep -i location  # see the bad version
location: https://blog.ubuntu.com/?fish=chips?fish=chips
$ curl -sI -H 'Host: insights.ubuntu.com' "`minikube ip`/?fish=chips" | grep -i location  # See the good version
Location: https://blog.ubuntu.com/?fish=chips
$ curl -sI -H 'Host: insights.staging ubuntu.com' "`minikube ip`/?fish=chips" | grep -i location  # See the good version
Location: https://blog.staging.ubuntu.com/?fish=chips
$ minikube stop
```

^ Check for `https` and only 1 set of query parameters in the new version.