### PR TITLE
Update all readiness and liveness checks to new defaults

### DIFF
--- a/services/beta.ubuntu.com.yaml
+++ b/services/beta.ubuntu.com.yaml
@@ -36,13 +36,14 @@ spec:
             httpGet:
               path: /
               port: 80
-            periodSeconds: 3
-            successThreshold: 3
+            timeoutSeconds: 3
+            periodSeconds: 5
           livenessProbe:
             httpGet:
               path: /
               port: 80
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            timeoutSeconds: 10
+            initialDelaySeconds: 15
+            periodSeconds: 15
 
 ---

--- a/services/canonical.com.yaml
+++ b/services/canonical.com.yaml
@@ -36,13 +36,14 @@ spec:
             httpGet:
               path: /
               port: 80
-            periodSeconds: 3
-            successThreshold: 3
+            timeoutSeconds: 3
+            periodSeconds: 5
           livenessProbe:
             httpGet:
               path: /
               port: 80
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            timeoutSeconds: 10
+            initialDelaySeconds: 15
+            periodSeconds: 15
 
 ---

--- a/services/cloud-init.io.yaml
+++ b/services/cloud-init.io.yaml
@@ -36,13 +36,14 @@ spec:
             httpGet:
               path: /
               port: 80
-            periodSeconds: 3
-            successThreshold: 3
+            timeoutSeconds: 3
+            periodSeconds: 5
           livenessProbe:
             httpGet:
               path: /
               port: 80
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            timeoutSeconds: 10
+            initialDelaySeconds: 15
+            periodSeconds: 15
 
 ---

--- a/services/cn.ubuntu.com.yaml
+++ b/services/cn.ubuntu.com.yaml
@@ -36,15 +36,14 @@ spec:
             httpGet:
               path: /_status/ping
               port: 80
-            periodSeconds: 3
-            successThreshold: 3
             timeoutSeconds: 3
+            periodSeconds: 5
           livenessProbe:
             httpGet:
               path: /_status/ping
               port: 80
-            initialDelaySeconds: 5
-            periodSeconds: 5
-            timeoutSeconds: 3
+            timeoutSeconds: 10
+            initialDelaySeconds: 15
+            periodSeconds: 15
 
 ---

--- a/services/conjure-up.io.yaml
+++ b/services/conjure-up.io.yaml
@@ -36,13 +36,14 @@ spec:
             httpGet:
               path: /
               port: 80
-            periodSeconds: 3
-            successThreshold: 3
+            timeoutSeconds: 3
+            periodSeconds: 5
           livenessProbe:
             httpGet:
               path: /
               port: 80
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            timeoutSeconds: 10
+            initialDelaySeconds: 15
+            periodSeconds: 15
 
 ---

--- a/services/design.ubuntu.com.yaml
+++ b/services/design.ubuntu.com.yaml
@@ -36,13 +36,14 @@ spec:
             httpGet:
               path: /
               port: 80
-            periodSeconds: 3
-            successThreshold: 3
+            timeoutSeconds: 3
+            periodSeconds: 5
           livenessProbe:
             httpGet:
               path: /
               port: 80
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            timeoutSeconds: 10
+            initialDelaySeconds: 15
+            periodSeconds: 15
 
 ---

--- a/services/developer.ubuntu.com.yaml
+++ b/services/developer.ubuntu.com.yaml
@@ -34,9 +34,16 @@ spec:
               containerPort: 80
           readinessProbe:
             httpGet:
-              path: /
+              path: /_status/check
               port: 80
-            periodSeconds: 3
-            successThreshold: 3
+            timeoutSeconds: 3
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /_status/check
+              port: 80
+            timeoutSeconds: 10
+            initialDelaySeconds: 15
+            periodSeconds: 15
 
 ---

--- a/services/docs.conjure-up.io.yaml
+++ b/services/docs.conjure-up.io.yaml
@@ -36,13 +36,14 @@ spec:
             httpGet:
               path: /
               port: 80
-            periodSeconds: 3
-            successThreshold: 3
+            timeoutSeconds: 3
+            periodSeconds: 5
           livenessProbe:
             httpGet:
               path: /
               port: 80
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            timeoutSeconds: 10
+            initialDelaySeconds: 15
+            periodSeconds: 15
 
 ---

--- a/services/docs.jujucharms.com.yaml
+++ b/services/docs.jujucharms.com.yaml
@@ -36,13 +36,14 @@ spec:
             httpGet:
               path: /
               port: 80
-            periodSeconds: 3
-            successThreshold: 3
+            timeoutSeconds: 3
+            periodSeconds: 5
           livenessProbe:
             httpGet:
               path: /
               port: 80
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            timeoutSeconds: 10
+            initialDelaySeconds: 15
+            periodSeconds: 15
 
 ---

--- a/services/docs.maas.io.yaml
+++ b/services/docs.maas.io.yaml
@@ -36,13 +36,14 @@ spec:
             httpGet:
               path: /
               port: 80
-            periodSeconds: 3
-            successThreshold: 3
+            timeoutSeconds: 3
+            periodSeconds: 5
           livenessProbe:
             httpGet:
               path: /
               port: 80
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            timeoutSeconds: 10
+            initialDelaySeconds: 15
+            periodSeconds: 15
 
 ---

--- a/services/docs.snapcraft.io.yaml
+++ b/services/docs.snapcraft.io.yaml
@@ -37,13 +37,14 @@ spec:
             httpGet:
               path: /
               port: 80
-            periodSeconds: 3
-            successThreshold: 3
+            timeoutSeconds: 3
+            periodSeconds: 5
           livenessProbe:
             httpGet:
               path: /
               port: 80
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            timeoutSeconds: 10
+            initialDelaySeconds: 15
+            periodSeconds: 15
 
 ---

--- a/services/docs.ubuntu.com.yaml
+++ b/services/docs.ubuntu.com.yaml
@@ -66,14 +66,15 @@ spec:
             httpGet:
               path: /
               port: 80
-            periodSeconds: 3
-            successThreshold: 3
+            timeoutSeconds: 3
+            periodSeconds: 5
           livenessProbe:
             httpGet:
               path: /
               port: 80
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            timeoutSeconds: 10
+            initialDelaySeconds: 15
+            periodSeconds: 15
 
 ---
 

--- a/services/docs.vanillaframework.io.yaml
+++ b/services/docs.vanillaframework.io.yaml
@@ -36,13 +36,14 @@ spec:
             httpGet:
               path: /
               port: 80
-            periodSeconds: 3
-            successThreshold: 3
+            timeoutSeconds: 3
+            periodSeconds: 5
           livenessProbe:
             httpGet:
               path: /
               port: 80
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            timeoutSeconds: 10
+            initialDelaySeconds: 15
+            periodSeconds: 15
 
 ---

--- a/services/jp.ubuntu.com.yaml
+++ b/services/jp.ubuntu.com.yaml
@@ -36,13 +36,14 @@ spec:
             httpGet:
               path: /
               port: 80
-            periodSeconds: 3
-            successThreshold: 3
+            timeoutSeconds: 3
+            periodSeconds: 5
           livenessProbe:
             httpGet:
               path: /
               port: 80
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            timeoutSeconds: 10
+            initialDelaySeconds: 15
+            periodSeconds: 15
 
 ---

--- a/services/maas.io.yaml
+++ b/services/maas.io.yaml
@@ -34,15 +34,16 @@ spec:
               containerPort: 80
           readinessProbe:
             httpGet:
-              path: /
+              path: /_status/check
               port: 80
-            periodSeconds: 3
-            successThreshold: 3
+            timeoutSeconds: 3
+            periodSeconds: 5
           livenessProbe:
             httpGet:
-              path: /
+              path: /_status/check
               port: 80
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            timeoutSeconds: 10
+            initialDelaySeconds: 15
+            periodSeconds: 15
 
 ---

--- a/services/netplan.io.yaml
+++ b/services/netplan.io.yaml
@@ -34,15 +34,16 @@ spec:
               containerPort: 80
           readinessProbe:
             httpGet:
-              path: /
+              path: /_status/check
               port: 80
-            periodSeconds: 3
-            successThreshold: 3
+            timeoutSeconds: 3
+            periodSeconds: 5
           livenessProbe:
             httpGet:
-              path: /
+              path: /_status/check
               port: 80
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            timeoutSeconds: 10
+            initialDelaySeconds: 15
+            periodSeconds: 15
 
 ---

--- a/services/snapcraft.io.yaml
+++ b/services/snapcraft.io.yaml
@@ -67,17 +67,16 @@ spec:
                   key: sentry_public_dsn
           readinessProbe:
             httpGet:
-              path: /status
+              path: /_status/check
               port: 80
-            periodSeconds: 3
-            successThreshold: 3
-            timeoutSeconds: 5
+            timeoutSeconds: 3
+            periodSeconds: 5
           livenessProbe:
             httpGet:
-              path: /status
+              path: /_status/check
               port: 80
-            initialDelaySeconds: 5
-            periodSeconds: 5
-            timeoutSeconds: 5
+            timeoutSeconds: 10
+            initialDelaySeconds: 15
+            periodSeconds: 15
 
 ---

--- a/services/tutorials.ubuntu.com.yaml
+++ b/services/tutorials.ubuntu.com.yaml
@@ -36,13 +36,14 @@ spec:
             httpGet:
               path: /
               port: 80
-            periodSeconds: 3
-            successThreshold: 3
+            timeoutSeconds: 3
+            periodSeconds: 5
           livenessProbe:
             httpGet:
               path: /
               port: 80
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            timeoutSeconds: 10
+            initialDelaySeconds: 15
+            periodSeconds: 15
 
 ---

--- a/services/usn.ubuntu.com.yaml
+++ b/services/usn.ubuntu.com.yaml
@@ -42,13 +42,14 @@ spec:
             httpGet:
               path: /
               port: 80
-            periodSeconds: 3
-            successThreshold: 3
+            timeoutSeconds: 3
+            periodSeconds: 5
           livenessProbe:
             httpGet:
               path: /
               port: 80
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            timeoutSeconds: 10
+            initialDelaySeconds: 15
+            periodSeconds: 15
 
 ---


### PR DESCRIPTION
QA
--
Check each service spins up properly, with

``` bash
./qa-deploy --production {domain} --tag latest
```