### PR TITLE
Revert netplan.io health check path from 9e9a1df

### DIFF
--- a/services/netplan.io.yaml
+++ b/services/netplan.io.yaml
@@ -34,13 +34,13 @@ spec:
               containerPort: 80
           readinessProbe:
             httpGet:
-              path: /_status/check
+              path: /
               port: 80
             timeoutSeconds: 3
             periodSeconds: 5
           livenessProbe:
             httpGet:
-              path: /_status/check
+              path: /
               port: 80
             timeoutSeconds: 10
             initialDelaySeconds: 15


### PR DESCRIPTION
netplan.io health check was updated to use a path which does not
currently exist on this site. This reverts the path only.