### PR TITLE
Enable env from threesixty config

### DIFF
--- a/services/360.canonical.com.yaml
+++ b/services/360.canonical.com.yaml
@@ -32,6 +32,10 @@ spec:
           ports:
             - name: http
               containerPort: 80
+          envFrom:
+            - configMapRef:
+                name: threesixty-canonical-com-config
+                optional: true
           env:
             - name: DATABASE_URL
               valueFrom:


### PR DESCRIPTION
Enable support for the environment variable config on 360

## QA

Please refer to here for some help on QA deployment: https://github.com/canonical-webteam/deployment-configs/pull/127

This should deploy successfully but no config is currently set up.