### PR TITLE
Add blog_enabled as env var to s.io

### DIFF
--- a/services/snapcraft.io.yaml
+++ b/services/snapcraft.io.yaml
@@ -45,6 +45,12 @@ spec:
                 configMapKeyRef:
                   name: global-config
                   key: environment
+            - name: BLOG_ENABLED
+              valueFrom:
+                configMapKeyRef:
+                  name: snapcraft-io
+                  optional: True
+                  key: blog_enabled
             - name: SECRET_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
# Summary

Add feature flag `BLOG_ENABLED` for snapcraft.io

# QA

- `./qa-deploy --tag acdddf4171d524606010bd8eb6b36b336eed3886 --production snapcraft.io`
- After doing modifications in you `/etc/hosts` access: http://snapcraft.io/blog
- Should get a 404 page

- Create file: `config.snapcraft.yaml`
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: snapcraft-io
data:
  blog_enabled: "True"
```
- `kubectl apply -f config.snapcraft.yaml`
- (make sure the replicas are well restarted, I don't know why sometimes locally mine doesn't restart. If it happens delete the replica set it should restart with this conf...)
-  http://snapcraft.io/blog
- You should access the blog page!