### PR TITLE
Add security-certs to docs.ubuntu.com

### DIFF
--- a/ingresses/production/docs.ubuntu.com.yaml
+++ b/ingresses/production/docs.ubuntu.com.yaml
@@ -28,5 +28,9 @@ spec:
         backend:
           serviceName: docs-ubuntu-com-phone
           servicePort: 80
+      - path: /security-certs
+        backend:
+          serviceName: docs-ubuntu-com-security-certs
+          servicePort: 80
 
 ---

--- a/ingresses/staging/docs.staging.ubuntu.com.yaml
+++ b/ingresses/staging/docs.staging.ubuntu.com.yaml
@@ -30,5 +30,9 @@ spec:
         backend:
           serviceName: docs-ubuntu-com-phone
           servicePort: 80
+      - path: /security-certs
+        backend:
+          serviceName: docs-ubuntu-com-security-certs
+          servicePort: 80
 
 ---

--- a/services/docs.ubuntu.com.yaml
+++ b/services/docs.ubuntu.com.yaml
@@ -30,6 +30,22 @@ spec:
 
 ---
 
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: docs-ubuntu-com-security-certs
+spec:
+  selector:
+    app: docs.ubuntu.com-security-certs
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http
+
+---
+
 kind: Service
 apiVersion: v1
 metadata:
@@ -92,6 +108,38 @@ spec:
       containers:
         - name: docs-ubuntu-com-core
           image: prod-comms.docker-registry.canonical.com/docs.ubuntu.com-core:${TAG_TO_DEPLOY_CORE}
+          ports:
+            - name: http
+              containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            periodSeconds: 3
+            successThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 5
+
+---
+
+kind: Deployment
+apiVersion: apps/v1beta1
+metadata:
+  name: docs-ubuntu-com-security-certs
+spec:
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        app: docs.ubuntu.com-security-certs
+    spec:
+      containers:
+        - name: docs-ubuntu-com-security-certs
+          image: prod-comms.docker-registry.canonical.com/docs.ubuntu.com-security-certs:${TAG_TO_DEPLOY_SECURITY_CERTS}
           ports:
             - name: http
               containerPort: 80


### PR DESCRIPTION
QA
--

``` bash
./qa-deploy --production docs.ubuntu.com --staging docs.staging.ubuntu.com --tag latest
```

Add `127.0.0.1 docs.ubuntu.com docs.staging.ubuntu.com` to your `/etc/hosts`, and try browsing to http://docs.ubuntu.com/security-certs and http://docs.staging.ubuntu.com/security-certs in a private window.