### PR TITLE
Add configs for mongoose.ubuntu.com

### DIFF
--- a/ingresses/production/mongoose.ubuntu.com.yaml
+++ b/ingresses/production/mongoose.ubuntu.com.yaml
@@ -3,20 +3,19 @@
 kind: Ingress
 apiVersion: extensions/v1beta1
 metadata:
-  name: beta-ubuntu-com
+  name: mongoose-ubuntu-com
   namespace: production
   annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       more_set_headers "X-Robots-Tag: noindex";
-      rewrite ^ http://mongoose.ubuntu.com$request_uri? redirect;
 spec:
   tls:
-  - secretName: beta-ubuntu-com-tls
+  - secretName: mongoose-ubuntu-com-tls
     hosts:
-    - beta.ubuntu.com
+    - mongoose.ubuntu.com
   rules:
-  - host: beta.ubuntu.com
+  - host: mongoose.ubuntu.com
     http:
       paths:
       - path: /

--- a/ingresses/staging/beta.staging.ubuntu.com.yaml
+++ b/ingresses/staging/beta.staging.ubuntu.com.yaml
@@ -9,6 +9,7 @@ metadata:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       more_set_headers "X-Robots-Tag: noindex";
+      rewrite ^ http://mongoose.staging.ubuntu.com$request_uri? redirect;
 spec:
   tls:
   - secretName: beta-staging-ubuntu-com-tls

--- a/ingresses/staging/mongoose.staging.ubuntu.com.yaml
+++ b/ingresses/staging/mongoose.staging.ubuntu.com.yaml
@@ -3,20 +3,19 @@
 kind: Ingress
 apiVersion: extensions/v1beta1
 metadata:
-  name: beta-ubuntu-com
-  namespace: production
+  name: mongoose-staging-ubuntu-com
+  namespace: staging
   annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       more_set_headers "X-Robots-Tag: noindex";
-      rewrite ^ http://mongoose.ubuntu.com$request_uri? redirect;
 spec:
   tls:
-  - secretName: beta-ubuntu-com-tls
+  - secretName: mongoose-staging-ubuntu-com-tls
     hosts:
-    - beta.ubuntu.com
+    - mongoose.staging.ubuntu.com
   rules:
-  - host: beta.ubuntu.com
+  - host: mongoose.staging.ubuntu.com
     http:
       paths:
       - path: /


### PR DESCRIPTION
This will be the domain under which we test the new beta changes for
www.ubuntu.com. It's called Mongoose, because we need to use a unique,
sacrificial domain name so that domain can then simply be redirected back to www.ubuntu.com
after the test completes.

The mongoose ingresses are in their own file, as this is the only way to
give them their own HTTPS certificate (like what we did for
insights.ubuntu.com).

For the time being I'm making `beta.ubuntu.com` redirect to `mongoose.ubuntu.com`, but it's only a `302` so we can undo it later to reclaim `beta.ubuntu.com`. For now I'm redirecting to `http://mongoose.ubuntu.com` rather than `https`, so we can test it before Mongoose's HTTPS cert arrives.

I've also added `X-Robots-Tag: noindex` to mongoose.ubuntu.com and
beta.ubuntu.com, as we don't want search engines sending people to
either.

QA
--

``` bash
./qa-deploy --staging beta.staging.ubuntu.com --production beta.ubuntu.com --tag latest
microk8s.kubectl apply -f ingresses/staging/mongoose.staging.ubuntu.com.yaml  # After removing the namespace from the file
microk8s.kubectl apply -f ingresses/production/mongoose.ubuntu.com.yaml  # After removing the namespace from the file
```

Add `127.0.0.1 beta.ubuntu.com beta.staging.ubuntu.com mongoose.ubuntu.com beta.mongoose.ubuntu.com` to your `/etc/hosts`. Check `beta.ubuntu.com` then redirects to mongoose, and that `mongoose.ubuntu.com` shows the beta.