### PR TITLE
Add limenet.snapcraft.io configuration

### DIFF
--- a/ingresses/production/limenet.snapcraft.io.yaml
+++ b/ingresses/production/limenet.snapcraft.io.yaml
@@ -1,0 +1,24 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: limenet-snapcraft-io
+  namespace: production
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  tls:
+  - secretName: limenet-snapcraft-io-tls
+    hosts:
+    - limenet.snapcraft.io
+  rules:
+  - host: limenet.snapcraft.io
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: limenet-snapcraft-io
+          servicePort: 80
+
+---

--- a/ingresses/staging/limenet.staging.snapcraft.io.yaml
+++ b/ingresses/staging/limenet.staging.snapcraft.io.yaml
@@ -1,0 +1,26 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: limenet-staging-snapcraft-io
+  namespace: staging
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "X-Robots-Tag: noindex";
+spec:
+  tls:
+  - secretName: limenet-staging-snapcraft-io-tls
+    hosts:
+    - limenet.staging.snapcraft.io
+  rules:
+  - host: limenet.staging.snapcraft.io
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: limenet-snapcraft-io
+          servicePort: 80
+
+---

--- a/services/limenet.snapcraft.io.yaml
+++ b/services/limenet.snapcraft.io.yaml
@@ -1,0 +1,49 @@
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: limenet-snapcraft-io
+spec:
+  selector:
+    app: limenet.snapcraft.io
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http
+
+---
+
+kind: Deployment
+apiVersion: apps/v1beta1
+metadata:
+  name: limenet-snapcraft-io
+spec:
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        app: limenet.snapcraft.io
+    spec:
+      containers:
+        - name: limenet-snapcraft-io
+          image: prod-comms.docker-registry.canonical.com/limenet.snapcraft.io:${TAG_TO_DEPLOY}
+          ports:
+            - name: http
+              containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /_status/check
+              port: 80
+            timeoutSeconds: 3
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /_status/check
+              port: 80
+            timeoutSeconds: 10
+            initialDelaySeconds: 15
+            periodSeconds: 15
+
+---


### PR DESCRIPTION
# Summary

Add configuration files to deploy our first brand store: `limenet.snapcraft.io` 

# QA

- Add line in `/etc/hosts` : 
`127.0.0.1         limenet.snapcraft.io limenet.staging.snapcraft.io` 

- `./qa-deploy --production limenet.snapcraft.io --staging limenet.staging.snapcraft.io --tag test-limenet`
- Access on a private brower: https://limenet.staging.snapcraft.io and https://limenet.snapcraft.io
- Should have a simple limenet store