### PR TITLE
Configs for microk8s

### DIFF
--- a/ingresses/production/microk8s.io.yaml
+++ b/ingresses/production/microk8s.io.yaml
@@ -1,0 +1,24 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: microk8s-io
+  namespace: production
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  tls:
+  - secretName: microk8s-io-tls
+    hosts:
+    - microk8s.io
+  rules:
+  - host: microk8s.io
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: microk8s-io
+          servicePort: 80
+
+---

--- a/ingresses/staging/staging.microk8s.io.yaml
+++ b/ingresses/staging/staging.microk8s.io.yaml
@@ -1,0 +1,26 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: staging-microk8s-io
+  namespace: staging
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "X-Robots-Tag: noindex";
+spec:
+  tls:
+  - secretName: staging-microk8s-io-tls
+    hosts:
+    - staging.microk8s.io
+  rules:
+  - host: staging.microk8s.io
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: microk8s-io
+          servicePort: 80
+
+---

--- a/services/microk8s.io.yaml
+++ b/services/microk8s.io.yaml
@@ -1,0 +1,49 @@
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: microk8s-io
+spec:
+  selector:
+    app: microk8s.io
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http
+
+---
+
+kind: Deployment
+apiVersion: apps/v1beta1
+metadata:
+  name: microk8s-io
+spec:
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        app: microk8s.io
+    spec:
+      containers:
+        - name: microk8s-io
+          image: prod-comms.docker-registry.canonical.com/microk8s.io:${TAG_TO_DEPLOY}
+          ports:
+            - name: http
+              containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /_status/check
+              port: 80
+            timeoutSeconds: 3
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /_status/check
+              port: 80
+            timeoutSeconds: 10
+            initialDelaySeconds: 15
+            periodSeconds: 15
+
+---


### PR DESCRIPTION
Deployment configs for microk8s.io and staging.microk8s.io.

QA
--

First, make sure you have, or have enabled, [microk8s](https://github.com/juju-solutions/microk8s). Then:

``` bash
./qa-deploy --production microk8s.io --staging staging.microk8s.io --tag alpha
watch microk8s.kubectl get all,ingress
echo "127.0.0.1 microk8s.io staging.microk8s.io" | sudo tee -a /etc/hosts
```

Once all pods are "running", browse to http://staging.microk8s.io and http://microk8s.io, and see the site running in all its glory.

Now clean up:

``` bash
sudo sed -i '/microk8s.io/d' /etc/hosts
```