### PR TITLE
Deployment configs for mir-server.io

### DIFF
--- a/ingresses/production/mir-server.io.yaml
+++ b/ingresses/production/mir-server.io.yaml
@@ -1,0 +1,24 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: mir-server-io
+  namespace: production
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  tls:
+  - secretName: mir-server-io-tls
+    hosts:
+    - mir-server.io
+  rules:
+  - host: mir-server.io
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: mir-server-io
+          servicePort: 80
+
+---

--- a/ingresses/staging/staging.mir-server.io.yaml
+++ b/ingresses/staging/staging.mir-server.io.yaml
@@ -1,0 +1,26 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: staging-mir-server-io
+  namespace: staging
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "X-Robots-Tag: noindex";
+spec:
+  tls:
+  - secretName: staging-mir-server-io-tls
+    hosts:
+    - staging.mir-server.io
+  rules:
+  - host: staging.mir-server.io
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: mir-server-io
+          servicePort: 80
+
+---

--- a/services/mir-server.io.yaml
+++ b/services/mir-server.io.yaml
@@ -1,0 +1,49 @@
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: mir-server-io
+spec:
+  selector:
+    app: mir-server.io
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http
+
+---
+
+kind: Deployment
+apiVersion: apps/v1beta1
+metadata:
+  name: mir-server-io
+spec:
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        app: mir-server.io
+    spec:
+      containers:
+        - name: mir-server-io
+          image: prod-comms.docker-registry.canonical.com/mir-server.io:${TAG_TO_DEPLOY}
+          ports:
+            - name: http
+              containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /_status/check
+              port: 80
+            timeoutSeconds: 3
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /_status/check
+              port: 80
+            timeoutSeconds: 10
+            initialDelaySeconds: 15
+            periodSeconds: 15
+
+---


### PR DESCRIPTION
Fixes #3

QA
--

After having microk8s running (you may need `microk8s.reset` and `snap disable microk8s; snap enable microk8s`):

``` bash
./qa-deploy --production mir-server.io --staging staging.mir-server.io --tag alpha
echo "127.0.0.1 mir-server.io staging.mir-server.io" | sudo tee -a /etc/hosts
watch microk8s.kubectl get all,ingress
```

Once all pods are "ready", open a new private window and browse to http://mir-server.io and http://staging.mir-server.io and http://mir-server.io/_status/check.

Then clean-up:

``` bash
sudo sed -i '/mir-server.io/d' /etc/hosts
microk8s.reset
snap disable microk8s
```