### PR TITLE
Improvements to qa-deploy script

### DIFF
--- a/qa-deploy
+++ b/qa-deploy
@@ -12,7 +12,6 @@ USAGE="Usage
 Description
 ---
 Deploy locally to microk8s.
-You must be connected to the Canonical VPN to use this script.
 
 --production: Deploy this ingress from the ingresses/production folder
 --staging: Deploy this ingress from the ingresses/staging folder
@@ -115,10 +114,6 @@ function run() {
 
     # Mandatory arguments
     if [ -z "${production:-}" ]; then invalid "No production domain specified (e.g. 'example.com')"; fi
-
-    echo -n "Are you connected to the VPN? [Y/n] "
-    read vpn
-    if [ "${vpn}" == "n" ]; then exit 0; fi
 
     run_microk8s
     add_secret_key

--- a/qa-deploy
+++ b/qa-deploy
@@ -62,10 +62,17 @@ function apply_configuration() {
 function run_microk8s() {
     # Run microk8s
     if ! command -v microk8s.kubectl &> /dev/null; then
-	echo "Please install or enable microk8s (https://github.com/juju-solutions/microk8s)"
-	echo ""
-	echo "    snap install microk8s --classic --edge"
-	exit 1
+        if ls /snap/microk8s &> /dev/null; then
+            echo "Enabling microk8s"
+            snap enable microk8s
+	    echo "> Waiting for microk8s to wake up ..."
+	    sleep 10
+        else
+            echo "Please install or enable microk8s (https://github.com/juju-solutions/microk8s)"
+            echo ""
+            echo "    snap install microk8s --classic --edge"
+            exit 1
+        fi
     fi
 
     if ! microk8s.kubectl get service/default-http-backend &> /dev/null; then


### PR DESCRIPTION
- Don't ask for VPN, we don't need it
- Enable microk8s if it's disabled

QA
--

``` bash
snap disable microk8s
./qa-deploy --production microk8s.io --tag latest
echo "127.0.0.1 microk8s.io" | sudo tee -a /etc/hosts
watch microk8s.kubectl get all,ingress
``

Check for all pods to be "ready".

Then open a private window and go to http://microk8s.io.

Now clean up:

``` bash
microk8s.reset
snap disable microk8s
sudo sed -i '/microk8s.io/d' /etc/hosts
```