### PR TITLE
multipass.run deployment configs

### DIFF
--- a/ingresses/production/multipass.run.yaml
+++ b/ingresses/production/multipass.run.yaml
@@ -1,0 +1,24 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: multipass-run
+  namespace: production
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  tls:
+  - secretName: multipass-run-tls
+    hosts:
+    - multipass.run
+  rules:
+  - host: multipass.run
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: multipass-run
+          servicePort: 80
+
+---

--- a/ingresses/staging/staging.multipass.run.yaml
+++ b/ingresses/staging/staging.multipass.run.yaml
@@ -1,0 +1,26 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: staging-multipass-run
+  namespace: staging
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "X-Robots-Tag: noindex";
+spec:
+  tls:
+  - secretName: staging-multipass-run-tls
+    hosts:
+    - staging.multipass.run
+  rules:
+  - host: staging.multipass.run
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: multipass-run
+          servicePort: 80
+
+---

--- a/services/multipass.run.yaml
+++ b/services/multipass.run.yaml
@@ -1,0 +1,49 @@
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: multipass-run
+spec:
+  selector:
+    app: multipass.run
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http
+
+---
+
+kind: Deployment
+apiVersion: apps/v1beta1
+metadata:
+  name: multipass-run
+spec:
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        app: multipass.run
+    spec:
+      containers:
+        - name: multipass-run
+          image: prod-comms.docker-registry.canonical.com/multipass.run:${TAG_TO_DEPLOY}
+          ports:
+            - name: http
+              containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /_status/check
+              port: 80
+            timeoutSeconds: 3
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /_status/check
+              port: 80
+            timeoutSeconds: 10
+            initialDelaySeconds: 15
+            periodSeconds: 15
+
+---


### PR DESCRIPTION
Fixes https://github.com/canonical-websites/multipass.run/issues/2

QA
--

``` bash
./qa-deploy --production multipass.run --staging staging.multipass.run --tag alpha
echo "127.0.0.1 multipass.run staging.multipass.run" | sudo tee -a /etc/hosts
watch microk8s.kubectl get all,ingress
```

Once all pods are "ready", open a new private window and browse to http://multipass.run and http://staging.multipass.run and http://multipass.run/_status/check.

Then clean-up:

``` bash
sudo sed -i '/multipass.run/d' /etc/hosts
microk8s.reset
microk8s.kubectl delete ingress --all
snap disable microk8s
```