### PR TITLE
Configs for ubuntu.com

### DIFF
--- a/ingresses/production/ubuntu.com.yaml
+++ b/ingresses/production/ubuntu.com.yaml
@@ -13,11 +13,6 @@ metadata:
       }
 
 spec:
-  tls:
-  - secretName: ubuntu-com-tls
-    hosts:
-    - ubuntu.com
-    - www.ubuntu.com
   rules:
   - host: ubuntu.com
     http:

--- a/ingresses/production/ubuntu.com.yaml
+++ b/ingresses/production/ubuntu.com.yaml
@@ -1,0 +1,37 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: ubuntu-com
+  namespace: production
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      if ($host = 'www.ubuntu.com' ) {
+        rewrite ^ https://ubuntu.com$request_uri? permanent;
+      }
+
+spec:
+  tls:
+  - secretName: ubuntu-com-tls
+    hosts:
+    - ubuntu.com
+    - www.ubuntu.com
+  rules:
+  - host: ubuntu.com
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: ubuntu-com
+          servicePort: 80
+  - host: www.ubuntu.com
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: ubuntu-com
+          servicePort: 80
+
+---

--- a/ingresses/staging/staging.ubuntu.com.yaml
+++ b/ingresses/staging/staging.ubuntu.com.yaml
@@ -1,0 +1,36 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: staging-ubuntu-com
+  namespace: staging
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "X-Robots-Tag: noindex";
+      if ($host = 'www.staging.ubuntu.com' ) {
+        rewrite ^ https://staging.ubuntu.com$request_uri? permanent;
+      }
+spec:
+  tls:
+  - secretName: staging-ubuntu-com-tls
+    hosts:
+    - staging.ubuntu.com
+  rules:
+  - host: staging.ubuntu.com
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: ubuntu-com
+          servicePort: 80
+  - host: www.staging.ubuntu.com
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: ubuntu-com
+          servicePort: 80
+
+---

--- a/services/ubuntu.com.yaml
+++ b/services/ubuntu.com.yaml
@@ -45,5 +45,11 @@ spec:
             timeoutSeconds: 10
             initialDelaySeconds: 15
             periodSeconds: 15
+          env:
+            - name: SEARCH_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: google-api
+                  key: search-api-key
 
 ---

--- a/services/ubuntu.com.yaml
+++ b/services/ubuntu.com.yaml
@@ -1,0 +1,49 @@
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: ubuntu-com
+spec:
+  selector:
+    app: ubuntu.com
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http
+
+---
+
+kind: Deployment
+apiVersion: apps/v1beta1
+metadata:
+  name: ubuntu-com
+spec:
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        app: ubuntu.com
+    spec:
+      containers:
+        - name: ubuntu-com
+          image: prod-comms.docker-registry.canonical.com/ubuntu.com:${TAG_TO_DEPLOY}
+          ports:
+            - name: http
+              containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /_status/check
+              port: 80
+            timeoutSeconds: 3
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /_status/check
+              port: 80
+            timeoutSeconds: 10
+            initialDelaySeconds: 15
+            periodSeconds: 15
+
+---


### PR DESCRIPTION
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/3815

QA
--

``` bash
./qa-deploy --production ubuntu.com --staging staging.ubuntu.com --tag 28ef964378ac7e39ba7b3aa787ad97cfd7620a76-1532680845
echo "127.0.0.1 ubuntu.com staging.ubuntu.com" | sudo tee -a
```

Go to https://ubuntu.com & https://staging.ubuntu.com in a private window.

Clean up:

``` bash
sudo sed -i 'd/ubuntu.com/' /etc/hosts
microk8s.reset
microk8s.kubectl ingress delete --all
snap disable microk8s
```