### PR TITLE
Redirect mirserver.io to mir-server.io

### DIFF
--- a/ingresses/production/mirserver.io.yaml
+++ b/ingresses/production/mirserver.io.yaml
@@ -1,0 +1,26 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: mirserver-io
+  namespace: production
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/configuration-snippet:
+      rewrite ^ https://mir-server.io$request_uri? permanent;
+spec:
+  tls:
+  - secretName: mirserver-io-tls
+    hosts:
+    - mirserver.io
+  rules:
+  - host: mirserver.io
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: mir-server-io
+          servicePort: 80
+
+---

--- a/ingresses/production/ubuntu.com.yaml
+++ b/ingresses/production/ubuntu.com.yaml
@@ -1,0 +1,37 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: ubuntu-com
+  namespace: production
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      if ($host = 'www.ubuntu.com' ) {
+        rewrite ^ https://ubuntu.com$request_uri? permanent;
+      }
+
+spec:
+  tls:
+  - secretName: ubuntu-com-tls
+    hosts:
+    - ubuntu.com
+    - www.ubuntu.com
+  rules:
+  - host: ubuntu.com
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: ubuntu-com
+          servicePort: 80
+  - host: www.ubuntu.com
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: ubuntu-com
+          servicePort: 80
+
+---

--- a/ingresses/staging/staging.ubuntu.com.yaml
+++ b/ingresses/staging/staging.ubuntu.com.yaml
@@ -1,0 +1,36 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: staging-ubuntu-com
+  namespace: staging
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "X-Robots-Tag: noindex";
+      if ($host = 'www.staging.ubuntu.com' ) {
+        rewrite ^ https://staging.ubuntu.com$request_uri? permanent;
+      }
+spec:
+  tls:
+  - secretName: staging-ubuntu-com-tls
+    hosts:
+    - staging.ubuntu.com
+  rules:
+  - host: staging.ubuntu.com
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: ubuntu-com
+          servicePort: 80
+  - host: www.staging.ubuntu.com
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: ubuntu-com
+          servicePort: 80
+
+---

--- a/services/ubuntu.com.yaml
+++ b/services/ubuntu.com.yaml
@@ -45,5 +45,11 @@ spec:
             timeoutSeconds: 10
             initialDelaySeconds: 15
             periodSeconds: 15
+          env:
+            - name: SEARCH_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: google-api
+                  key: search-api-key
 
 ---

--- a/services/ubuntu.com.yaml
+++ b/services/ubuntu.com.yaml
@@ -1,0 +1,49 @@
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: ubuntu-com
+spec:
+  selector:
+    app: ubuntu.com
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http
+
+---
+
+kind: Deployment
+apiVersion: apps/v1beta1
+metadata:
+  name: ubuntu-com
+spec:
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        app: ubuntu.com
+    spec:
+      containers:
+        - name: ubuntu-com
+          image: prod-comms.docker-registry.canonical.com/ubuntu.com:${TAG_TO_DEPLOY}
+          ports:
+            - name: http
+              containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /_status/check
+              port: 80
+            timeoutSeconds: 3
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /_status/check
+              port: 80
+            timeoutSeconds: 10
+            initialDelaySeconds: 15
+            periodSeconds: 15
+
+---


### PR DESCRIPTION
QA
--

``` bash
$ snap enable microk8s  # Wait a minute for it to spin up
$ microk8s.enable ingress
$ sed '/namespace:/d' ingresses/production/mirserver.io.yaml | microk8s.kubectl apply -f -
$ curl -I -H 'Host: mirserver.io' 127.0.0.1
HTTP/1.1 301 Moved Permanently
Server: nginx/1.13.12
Date: Mon, 30 Jul 2018 10:13:27 GMT
Content-Type: text/html
Content-Length: 186
Connection: keep-alive
Location: https://mir-server.io/
```