### PR TITLE
Use one secret for all cloud-init domains

### DIFF
--- a/ingresses/production/cloud-init-io.yaml
+++ b/ingresses/production/cloud-init-io.yaml
@@ -17,8 +17,6 @@ spec:
     hosts:
     - cloud-init.io
     - www.cloud-init.io
-  - secretName: cloud-init-org-tls
-    hosts:
     - cloud-init.org
     - www.cloud-init.org
   rules:


### PR DESCRIPTION
See: https://portal.admin.canonical.com/C113488/

(This isn't really possible to QA, but I've already applied the change to production)