### PR TITLE
Try limiting phone docs' memory to 128MiB

### DIFF
--- a/services/docs-ubuntu-com-phone.yaml
+++ b/services/docs-ubuntu-com-phone.yaml
@@ -44,5 +44,8 @@ spec:
               port: 80
             initialDelaySeconds: 5
             periodSeconds: 5
+          resources:
+            limits:
+              memory: "128Mi"
 
 ---


### PR DESCRIPTION
Phone docs is still using a huge amount of memory, even with nginx. Although everything I can find suggests that nginx should be much more memory efficient.

It appears that it could be a problem with containers not reclaiming their memory properly:
https://stackoverflow.com/questions/41048742/nginx-content-caching-causing-docker-memory-spike
https://stackoverflow.com/questions/41604669/memory-used-metric-go-tool-pprof-vs-docker-stats/41687155#41687155

Here I'm experimenting with setting a resource limit of 128MiB for the containers, as described in the docs:
https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-memory