### PR TITLE
Redirect design.canonical.com to the blog

### DIFF
--- a/ingresses/production/blog-ubuntu-com.yaml
+++ b/ingresses/production/blog-ubuntu-com.yaml
@@ -8,6 +8,10 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/configuration-snippet: |
+      if ($host = 'design.canonical.com') {
+        rewrite ^ https://blog.ubuntu.com/topics/design;
+      }
+
       if ($host != 'blog.ubuntu.com' ) {
         rewrite ^ https://blog.ubuntu.com$request_uri? permanent;
       }
@@ -16,9 +20,8 @@ spec:
   - secretName: blog-ubuntu-com-tls
     hosts:
     - blog.ubuntu.com
-  - secretName: insights-ubuntu-com-tls
-    hosts:
     - insights.ubuntu.com
+    - design.canonical.com
   rules:
   - host: blog.ubuntu.com
     http: &blog-ubuntu-com_service
@@ -30,6 +33,8 @@ spec:
 
   # Alias domains
   - host: insights.ubuntu.com
+    http: *blog-ubuntu-com_service
+  - host: design.canonical.com
     http: *blog-ubuntu-com_service
 
 ---


### PR DESCRIPTION
QA
--

```
echo "127.0.0.1 design.canonical.com" | sudo tee -a /etc/hosts
./qa-deploy --production blog.ubuntu.com --tag fix-talisker-entrypoint
curl -I http://design.canonical.com
```

See that it redirects you to a working `/topic/design` page on blog.ubuntu.com