### PR TITLE
Revert "Redirect design.canonical.com to the blog"

### DIFF
--- a/ingresses/production/blog-ubuntu-com.yaml
+++ b/ingresses/production/blog-ubuntu-com.yaml
@@ -8,10 +8,6 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/configuration-snippet: |
-      if ($host = 'design.canonical.com') {
-        rewrite ^ https://blog.ubuntu.com/topics/design;
-      }
-
       if ($host != 'blog.ubuntu.com' ) {
         rewrite ^ https://blog.ubuntu.com$request_uri? permanent;
       }
@@ -20,8 +16,9 @@ spec:
   - secretName: blog-ubuntu-com-tls
     hosts:
     - blog.ubuntu.com
+  - secretName: insights-ubuntu-com-tls
+    hosts:
     - insights.ubuntu.com
-    - design.canonical.com
   rules:
   - host: blog.ubuntu.com
     http: &blog-ubuntu-com_service
@@ -33,8 +30,6 @@ spec:
 
   # Alias domains
   - host: insights.ubuntu.com
-    http: *blog-ubuntu-com_service
-  - host: design.canonical.com
     http: *blog-ubuntu-com_service
 
 ---


### PR DESCRIPTION
Reverts canonical-webteam/deployment-configs#166

This has multiple issues:

- We need to ensure the `blog-ubuntu-com-tls` cert can handle `insights.ubuntu.com` and `design.canonical.com`
- In fact, we need to be able to handle URLs for intelligently for design.canonical.com, e.g.:
  - `https://design.canonical.com/2017/07/snapcraft/` -> `https://insights.ubuntu.com/2017/07/snapcraft/`
  - `https://design.canonical.com/2013/11` -> `https://insights.ubuntu.com/archives?year=2013&month=11`