### PR TITLE
Add staging-api.snapcraft.io

### DIFF
--- a/ingresses/staging/staging-api-snapcraft-io.yaml
+++ b/ingresses/staging/staging-api-snapcraft-io.yaml
@@ -1,0 +1,26 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1  # See https://bit.ly/2KdOtrZ
+metadata:
+  name: staging-api-snapcraft-io
+  namespace: staging
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "X-Robots-Tag: noindex";
+spec:
+  tls:
+  - secretName: staging-api-snapcraft-io-tls
+    hosts:
+    - staging-api.snapcraft.io
+  rules:
+  - host: staging-api.snapcraft.io
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: staging-api-snapcraft-io
+          servicePort: 80
+
+---

--- a/services/staging-api-snapcraft-io.yaml
+++ b/services/staging-api-snapcraft-io.yaml
@@ -1,0 +1,89 @@
+---
+
+kind: Service
+apiVersion: v1  # See https://bit.ly/2KdOtrZ
+metadata:
+  name: staging-api-snapcraft-io
+spec:
+  selector:
+    app: staging-api.snapcraft.io
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http
+
+---
+
+kind: Deployment
+apiVersion: extensions/v1beta1  # See https://bit.ly/2KdOtrZ
+metadata:
+  name: staging-api-snapcraft-io
+spec:
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        app: staging-api.snapcraft.io
+    spec:
+      containers:
+        - name: staging-api-snapcraft-io
+          image: prod-comms.docker-registry.canonical.com/snapcraft.io:${TAG_TO_DEPLOY}
+          ports:
+            - name: http
+              containerPort: 80
+          envFrom:
+            - configMapRef:
+                name: proxy-config
+                optional: true
+            - configMapRef:
+                name: staging-api-snapcraft-io
+          env:
+            - name: ENVIRONMENT
+              valueFrom:
+                configMapKeyRef:
+                  name: global-config
+                  key: environment
+            - name: BSI_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: snapcraft-io
+                  optional: true
+                  key: bsi_url
+            - name: BLOG_ENABLED
+              valueFrom:
+                configMapKeyRef:
+                  name: snapcraft-io
+                  optional: True
+                  key: blog_enabled
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: snapcraft-io-config
+                  key: secret_key
+            - name: WTF_CSRF_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: snapcraft-io-config
+                  key: csrf_secret_key
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: snapcraft-io-config
+                  key: sentry_dsn
+            - name: SENTRY_PUBLIC_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: snapcraft-io-config
+                  key: sentry_public_dsn
+          readinessProbe:
+            httpGet:
+              path: /_status/check
+              port: 80
+            timeoutSeconds: 3
+            periodSeconds: 5
+          resources:
+            limits:
+              memory: "256Mi"
+
+---


### PR DESCRIPTION
# Summary

Add staging-api.snapcraft.io
This instance will allow snap team to play on snapcraft.io with the staging API

# QA

- `vim config.staging-api.snapcraft.yaml`

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: staging-api-snapcraft-io
data:
  SNAPCRAFT_IO_API: https://api.staging.snapcraft.io/api/v1/
  SNAPCRAFT_IO_API_V2: https://api.staging.snapcraft.io/v2/
  DASHBOARD_API: https://dashboard.staging.snapcraft.io/dev/api/
  DASHBOARD_API_V2: https://dashboard.staging.snapcraft.io/api/v2/
  LOGIN_URL: https://login.staging.ubuntu.com
```

- `microk8s.kubectl apply -f config.staging-api.snapcraft.yaml`
- `./qa-deploy --staging staging-api.snapcraft.io --tag latest`
- `echo "127.0.0.1 staging-api.snapcraft.io" | sudo tee -a /etc/hosts`
- access http://staging-api.snapcraft.io/store
- You should have staging snaps displayed

