### PR TITLE
Clean snapcraft.io Deployement config

### DIFF
--- a/config.production.yaml
+++ b/config.production.yaml
@@ -16,4 +16,4 @@ metadata:
   name: global-config
   namespace: production
 data:
-  environment: "production"
+  ENVIRONMENT: "production"

--- a/config.staging.yaml
+++ b/config.staging.yaml
@@ -16,4 +16,4 @@ metadata:
   name: global-config
   namespace: staging
 data:
-  environment: "staging"
+  ENVIRONMENT: "staging"

--- a/qa-deploy
+++ b/qa-deploy
@@ -28,7 +28,7 @@ function invalid() {
 
 function add_secret_key() {
     if ! microk8s.kubectl get secret snapcraft-io-config &> /dev/null; then
-        microk8s.kubectl create secret generic snapcraft-io-config --from-literal=secret_key=admin --from-literal=csrf_secret_key=admin --from-literal='sentry_dsn=' --from-literal='sentry_public_dsn='
+        microk8s.kubectl create secret generic snapcraft-io-config --from-literal=SECRET_KEY=admin --from-literal=CSRF_SECRET_KEY=admin --from-literal='SENTRY_DSN=' --from-literal='SENTRY_PUBLIC_DSN='
     fi
 }
 

--- a/services/snapcraft-io.yaml
+++ b/services/snapcraft-io.yaml
@@ -19,15 +19,12 @@ kind: Deployment
 apiVersion: extensions/v1beta1
 metadata:
   name: snapcraft-io
-  labels:
-    useProxy: "true"
 spec:
   replicas: 9
   template:
     metadata:
       labels:
         app: snapcraft.io
-        useProxy: "true"
     spec:
       containers:
         - name: snapcraft-io
@@ -39,44 +36,13 @@ spec:
             - configMapRef:
                 name: proxy-config
                 optional: true
-          env:
-            - name: ENVIRONMENT
-              valueFrom:
-                configMapKeyRef:
-                  name: global-config
-                  key: environment
-            - name: BSI_URL
-              valueFrom:
-                configMapKeyRef:
-                  name: snapcraft-io
-                  optional: true
-                  key: bsi_url
-            - name: BLOG_ENABLED
-              valueFrom:
-                configMapKeyRef:
-                  name: snapcraft-io
-                  optional: True
-                  key: blog_enabled
-            - name: SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: snapcraft-io-config
-                  key: secret_key
-            - name: WTF_CSRF_SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: snapcraft-io-config
-                  key: csrf_secret_key
-            - name: SENTRY_DSN
-              valueFrom:
-                secretKeyRef:
-                  name: snapcraft-io-config
-                  key: sentry_dsn
-            - name: SENTRY_PUBLIC_DSN
-              valueFrom:
-                secretKeyRef:
-                  name: snapcraft-io-config
-                  key: sentry_public_dsn
+            - configMapRef:
+                name: global-config
+            - configMapRef:
+                name: snapcraft-io
+                optional: true
+            - secretRef:
+                name: snapcraft-io-config
           readinessProbe:
             httpGet:
               path: /_status/check


### PR DESCRIPTION
# Summary

Clean deployement configuration for snapcraft.io
Instead of importing one by one the ENV from the configmaps, import the entire config map (since we use all the variables from it)

# QA 

- `./qa-deploy --production snapcraft.io --tag latest`