### PR TITLE
Add mainteance mode vars

### DIFF
--- a/config.production.yaml
+++ b/config.production.yaml
@@ -16,4 +16,4 @@ metadata:
   name: global-config
   namespace: production
 data:
-  environment: "production"
+  ENVIRONMENT: "production"

--- a/config.staging.yaml
+++ b/config.staging.yaml
@@ -16,4 +16,4 @@ metadata:
   name: global-config
   namespace: staging
 data:
-  environment: "staging"
+  ENVIRONMENT: "staging"

--- a/qa-deploy
+++ b/qa-deploy
@@ -28,7 +28,7 @@ function invalid() {
 
 function add_secret_key() {
     if ! microk8s.kubectl get secret snapcraft-io-config &> /dev/null; then
-        microk8s.kubectl create secret generic snapcraft-io-config --from-literal=secret_key=admin --from-literal=csrf_secret_key=admin --from-literal='sentry_dsn=' --from-literal='sentry_public_dsn='
+        microk8s.kubectl create secret generic snapcraft-io-config --from-literal=SECRET_KEY=admin --from-literal=CSRF_SECRET_KEY=admin --from-literal='SENTRY_DSN=' --from-literal='SENTRY_PUBLIC_DSN='
     fi
 }
 

--- a/services/snapcraft-io.yaml
+++ b/services/snapcraft-io.yaml
@@ -19,15 +19,12 @@ kind: Deployment
 apiVersion: extensions/v1beta1
 metadata:
   name: snapcraft-io
-  labels:
-    useProxy: "true"
 spec:
   replicas: 9
   template:
     metadata:
       labels:
         app: snapcraft.io
-        useProxy: "true"
     spec:
       containers:
         - name: snapcraft-io
@@ -39,44 +36,13 @@ spec:
             - configMapRef:
                 name: proxy-config
                 optional: true
-          env:
-            - name: ENVIRONMENT
-              valueFrom:
-                configMapKeyRef:
-                  name: global-config
-                  key: environment
-            - name: BSI_URL
-              valueFrom:
-                configMapKeyRef:
-                  name: snapcraft-io
-                  optional: true
-                  key: bsi_url
-            - name: BLOG_ENABLED
-              valueFrom:
-                configMapKeyRef:
-                  name: snapcraft-io
-                  optional: True
-                  key: blog_enabled
-            - name: SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: snapcraft-io-config
-                  key: secret_key
-            - name: WTF_CSRF_SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: snapcraft-io-config
-                  key: csrf_secret_key
-            - name: SENTRY_DSN
-              valueFrom:
-                secretKeyRef:
-                  name: snapcraft-io-config
-                  key: sentry_dsn
-            - name: SENTRY_PUBLIC_DSN
-              valueFrom:
-                secretKeyRef:
-                  name: snapcraft-io-config
-                  key: sentry_public_dsn
+            - configMapRef:
+                name: global-config
+            - configMapRef:
+                name: snapcraft-io
+                optional: true
+            - secretRef:
+                name: snapcraft-io-config
           readinessProbe:
             httpGet:
               path: /_status/check

--- a/services/snapcraft-io.yaml
+++ b/services/snapcraft-io.yaml
@@ -43,6 +43,15 @@ spec:
                 optional: true
             - secretRef:
                 name: snapcraft-io-config
+          env:
+            - name: MAINTENANCE_MODE_STORE
+              value: ${MAINTENANCE_MODE_STORE}
+            - name: MAINTENANCE_MODE_PUBLISHER
+              value: ${MAINTENANCE_MODE_PUBLISHER}
+            - name: MAINTENANCE_MODE_BLOG
+              value: ${MAINTENANCE_MODE_BLOG}
+            - name: MAITENANCE_MODE_LOGIN
+              value: ${MAINTENANCE_MODE_LOGIN}
           readinessProbe:
             httpGet:
               path: /_status/check


### PR DESCRIPTION
# Summary

PR made after the cleanup https://github.com/canonical-webteam/deployment-configs/pull/186
Add maintenance mode variables for each API on snapcraft.
This will allow us to have a job that we can run when we want to put snapcraft into a maintenance mode.

Code for snapcraft.io: https://github.com/canonical-websites/snapcraft.io/pull/1215

This is just to open a discussion about maintenance mode, no QA for now.