### PR TITLE
Add sentry to blog

### DIFF
--- a/services/blog-ubuntu-com.yaml
+++ b/services/blog-ubuntu-com.yaml
@@ -32,6 +32,12 @@ spec:
           ports:
             - name: http
               containerPort: 80
+          env:
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: sentry-dsn
+                  key: blog-ubuntu-com
           readinessProbe:
             httpGet:
               path: /_status/check


### PR DESCRIPTION
# Summary

Add sentry config to blog 

# QA

- Create file `config.blog.yaml`:
```yaml
apiVersion: v1
kind: Secret
metadata:
  name: sentry-dsn
  namespace: production
type: Opaque
data:
  blog-ubuntu-com: aHR0cHM6Ly9rZXk6c2VjcmV0QHNlbnRyeS5pcy5jYW5vbmljYWwuY29tLy8xCg==
```
- `microk8s.kubectl -f config.blog.yaml`
- `./qa-deploy --production blog.ubuntu.com --tag latest`
- Make sure pod has the right dsn (you can see it from the dashboard)