### PR TITLE
Add sentry sites to jaas.ai and docs.snapcraft.io

### DIFF
--- a/services/docs-snapcraft-io.yaml
+++ b/services/docs-snapcraft-io.yaml
@@ -33,6 +33,12 @@ spec:
           ports:
             - name: http
               containerPort: 80
+          env:
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: sentry-dsn
+                  key: docs-snapcraft-io
           readinessProbe:
             httpGet:
               path: /

--- a/services/jaas-ai.yaml
+++ b/services/jaas-ai.yaml
@@ -32,6 +32,12 @@ spec:
           ports:
             - name: http
               containerPort: 80
+          env:
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: sentry-dsn
+                  key: jaas-ai
           readinessProbe:
             httpGet:
               path: /_status/check

--- a/services/maas-io.yaml
+++ b/services/maas-io.yaml
@@ -32,6 +32,12 @@ spec:
           ports:
             - name: http
               containerPort: 80
+          env:
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: sentry-dsn
+                  key: maas-io
           readinessProbe:
             httpGet:
               path: /_status/check


### PR DESCRIPTION
# Summary

Fixes #248
Add sentry config to jaas.ai and docs.snapcraft.io 

# QA

- Create file `config.blog.yaml`:
```yaml
apiVersion: v1
kind: Secret
metadata:
  name: sentry-dsn
type: Opaque
data:
  jaas-ai: aHR0cHM6Ly9rZXk6c2VjcmV0QHNlbnRyeS5pcy5jYW5vbmljYWwuY29tLy8xCg==
  maas-io: aHR0cHM6Ly9rZXk6c2VjcmV0QHNlbnRyeS5pcy5jYW5vbmljYWwuY29tLy8xCg==
  docs-snapcraft-io: aHR0cHM6Ly9rZXk6c2VjcmV0QHNlbnRyeS5pcy5jYW5vbmljYWwuY29tLy8xCg==
```
- `microk8s.kubectl -f config.blog.yaml`
- `./qa-deploy --production jaas.ai --tag latest`
- `./qa-deploy --production docs.snapcraft.io --tag latest`
- `./qa-deploy --production maas.io --tag latest`
- Make sure pod has the right dsn (you can see it from the dashboard)