### PR TITLE
Update nginx config and fix qa script

### DIFF
--- a/config.global.yaml
+++ b/config.global.yaml
@@ -1,11 +1,12 @@
 apiVersion: v1
 data:
   # Change redirect code to 301 as 308 is not understood by social media bots
+  body-size: "0"
   http-redirect-code: "301"
   map-hash-bucket-size: "128"
-  proxy-buffer-size: 8k
-  proxy-buffers: 4 8k
-  proxy-body-size: 1024m
+  proxy-body-size: "0"
+  proxy-buffer-size: "8k"
+  proxy-buffers: "4 8k"
 kind: ConfigMap
 metadata:
-  name: nginx-load-balancer-conf
+  name: nginx-configuration

--- a/qa-deploy
+++ b/qa-deploy
@@ -55,8 +55,12 @@ function add_docker_credentials_microk8s() {
 }
 
 function apply_configuration() {
-    microk8s.kubectl apply -f config.global.yaml --namespace kube-system
     microk8s.kubectl apply -f config.qa.yaml
+
+    # On the version of the ingress controller we have we need to change the
+    # name to be able to apply the configuration. By default the nginx ingress
+    # controller is searching for a config-map called: nginx-load-balancer-conf
+    cat "config.global.yaml" | sed 's|name: nginx-configuration|name: nginx-load-balancer-conf|' | microk8s.kubectl apply --filename - --namespace default
 }
 
 function run_microk8s() {
@@ -74,10 +78,12 @@ function run_microk8s() {
             exit 1
         fi
     fi
+}
 
+function enable_ingress() {
     if ! microk8s.kubectl get service/default-http-backend &> /dev/null; then
         echo "HTTP backend not found: Enabling ingress addon"
-        microk8s.enable ingress
+        microk8s.enable ingress dns
     fi
 }
 
@@ -123,6 +129,10 @@ function run() {
     if [ -z "${production:-}" ]; then invalid "No production domain specified (e.g. 'example.com')"; fi
 
     run_microk8s
+    # The configuration needs to run before the ingress controller starts 
+    # because it doesn't restart when applying the configuration after.
+    apply_configuration
+    enable_ingress
     add_secret_key
 
     add_docker_credentials_microk8s
@@ -134,7 +144,6 @@ function run() {
     deploy_ingress "production/${production}"
 
     if [ -n "${staging:-}" ]; then deploy_ingress "staging/${staging}"; fi
-    apply_configuration
 }
 
 run ${@}


### PR DESCRIPTION
# Summary 

Since the lastest update of our k8s cluster here are some modifications on the nginx-ingress-controller modifications:

- rename ConfigMap from `nginx-load-balancer-conf` to `nginx-configuration`:
  -  `nginx-load-balancer-conf`: Default ConfigMap name used in microk8s version of the nginx ingress controller 
  - `nginx-configuration`: Default name used on our k8s cluster.
- Modify way to apply the configuration in the QA script (by renaming the name of the nginx-configuration ConfigMap)
- Move the enable ingress to own function
- Enable also the DNS pod to be able to make API calls
- Apply the configuration before start the ingress pod (read comment)
- **Not on the PR** changed the namespace on the jenkins jobs from `default` to `ingress-nginx-kubernetes-worker`

# QA

- `microk8s.reset`
- `./qa-deploy --production snapcraft.io --tag latest `
- `sudo emacs -nw /etc/hosts`
- Add `127.0.0.1 snapcraft.io`
- On a private window: http://snapcraft.io
- Navigate on the website and try to login
- Everything should work as usual