### PR TITLE
Add landscape brochure config

### DIFF
--- a/ingresses/production/landscape-brochure-internal.yaml
+++ b/ingresses/production/landscape-brochure-internal.yaml
@@ -1,0 +1,33 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1  # See https://bit.ly/2KdOtrZ
+metadata:
+  name: landscape-brochure-internal
+  namespace: production
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      if ($host != 'landscape-brochure.internal' ) {
+        rewrite ^ https://landscape-brochure.internal$request_uri? permanent;
+      }
+spec:
+  tls:
+  - secretName: landscape-brochure-internal-tls
+    hosts:
+    - landscape-brochure.internal
+    - www.landscape-brochure.internal
+  rules:
+  - host: landscape-brochure.internal
+    http: &landscape-brochure-internal_service
+      paths:
+      - path: /
+        backend:
+          serviceName: landscape-brochure-internal
+          servicePort: 80
+
+  # Alias domains
+  - host: www.landscape-brochure.internal
+    http: *landscape-brochure-internal_service
+
+---

--- a/ingresses/staging/landscape-brochure-staging-internal.yaml
+++ b/ingresses/staging/landscape-brochure-staging-internal.yaml
@@ -1,0 +1,26 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1  # See https://bit.ly/2KdOtrZ
+metadata:
+  name: landscape-brochure-staging-internal
+  namespace: staging
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "X-Robots-Tag: noindex";
+spec:
+  tls:
+  - secretName: staging-landscape-brochure-internal-tls
+    hosts:
+    - landscape-brochure.staging.internal
+  rules:
+  - host: landscape-brochure.staging.internal
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: landscape-brochure-internal
+          servicePort: 80
+
+---

--- a/services/landscape-brochure-internal.yaml
+++ b/services/landscape-brochure-internal.yaml
@@ -1,0 +1,45 @@
+---
+
+kind: Service
+apiVersion: v1  # See https://bit.ly/2KdOtrZ
+metadata:
+  name: landscape-brochure-internal
+spec:
+  selector:
+    app: landscape-brochure.internal
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http
+
+---
+
+kind: Deployment
+apiVersion: extensions/v1beta1  # See https://bit.ly/2KdOtrZ
+metadata:
+  name: landscape-brochure-internal
+spec:
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        app: landscape-brochure.internal
+    spec:
+      containers:
+        - name: landscape-brochure-internal
+          image: prod-comms.docker-registry.canonical.com/landscape-brochure.internal:${TAG_TO_DEPLOY}
+          ports:
+            - name: http
+              containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /_status/check
+              port: 80
+            timeoutSeconds: 3
+            periodSeconds: 5
+          resources:
+            limits:
+              memory: "256Mi"
+
+---


### PR DESCRIPTION
# DON'T QA YET I NEED TO PUBLISH ON OUR HUB THE DOCKER IMAGE

# Summary

Fixes https://github.com/ubuntudesign/base-squad/issues/273
- Add configuration for landscape-brochure.internal new project

# QA

- in `/etc/hosts` add lines:

```
127.0.0.1  landscape-brochure.staging.internal landscape-brochure.internal
```
- `./qa-deploy --stagin landscape-brochure.staging.internal --production landscape-brochure.internal --tag test`
- Try to access websites, it should work as usual