### PR TITLE
Add engage.canonical.com configuration

### DIFF
--- a/ingresses/production/engage-canonical-com.yaml
+++ b/ingresses/production/engage-canonical-com.yaml
@@ -1,0 +1,24 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1  # See https://bit.ly/2KdOtrZ
+metadata:
+  name: engage-canonical-com
+  namespace: production
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  tls:
+  - secretName: engage-canonical-com-tls
+    hosts:
+    - engage.canonical.com
+  rules:
+  - host: engage.canonical.com
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: engage-canonical-com
+          servicePort: 80
+
+---

--- a/ingresses/staging/engage-staging-canonical-com.yaml
+++ b/ingresses/staging/engage-staging-canonical-com.yaml
@@ -1,0 +1,26 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1  # See https://bit.ly/2KdOtrZ
+metadata:
+  name: engage-staging-canonical-com
+  namespace: staging
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "X-Robots-Tag: noindex";
+spec:
+  tls:
+  - secretName: engage-staging-canonical-com-tls
+    hosts:
+    - engage.staging.canonical.com
+  rules:
+  - host: engage.staging.canonical.com
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: engage-canonical-com
+          servicePort: 80
+
+---

--- a/services/engage-canonical-com.yaml
+++ b/services/engage-canonical-com.yaml
@@ -1,0 +1,51 @@
+---
+
+kind: Service
+apiVersion: v1  # See https://bit.ly/2KdOtrZ
+metadata:
+  name: engage-canonical-com
+spec:
+  selector:
+    app: engage.canonical.com
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http
+
+---
+
+kind: Deployment
+apiVersion: extensions/v1beta1  # See https://bit.ly/2KdOtrZ
+metadata:
+  name: engage-canonical-com
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: engage.canonical.com
+    spec:
+      containers:
+        - name: engage-canonical-com
+          image: prod-comms.docker-registry.canonical.com/engage.canonical.com:${TAG_TO_DEPLOY}
+          ports:
+            - name: http
+              containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /_status/check
+              port: 80
+            timeoutSeconds: 3
+            periodSeconds: 5
+          resources:
+            limits:
+              memory: "256Mi"
+          env:
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: prototype-secret-key
+                  key: secret_key
+
+---


### PR DESCRIPTION
# Summary

- Add config for engage.canonical.com

# QA

- Create file `secret.yaml` and insert:
```yaml
apiVersion: v1
kind: Secret
metadata:
  name: prototype-secret-key
type: Opaque
data:
  secret_key: dGhpc2lzYXNlY3JldGtleQ==
```
- `microk8s.kubectl apply -f secret.yaml`
- `./qa-deploy --production engage.canonical.com --tag test`
- Make sure site is well deployed
