### PR TITLE
Add spreadsheet url to report snap

### DIFF
--- a/services/snapcraft-io.yaml
+++ b/services/snapcraft-io.yaml
@@ -57,6 +57,11 @@ spec:
                   name: snapcraft-io
                   optional: True
                   key: blog_enabled
+            - name: SPREADSHEET_REPORT_SNAP
+              valueFrom:
+                secretKeyRef:
+                  name: snapcraft-io
+                  key: spreadsheet_report_snap
             - name: SECRET_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
# SUMMARY

See https://github.com/canonical-websites/snapcraft.io/pull/1572
Add spreadsheet to be able to report snap

# QA

- `emacs -nw config.snapcraft.yaml`
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: snapcraft-io
data:
  SPREADSHEET_REPORT_SNAP: "https://this.is.a.url"
```
- `microk8s.kubectl apply  -f config.snapcraft.yaml`
- `./qa-deploy --production snapcraft.io --tag latest`