### PR TITLE
Increase memory from 256Mi to 512Mi for stagingapi snapcraft.io

### DIFF
--- a/services/staging-api-snapcraft-io.yaml
+++ b/services/staging-api-snapcraft-io.yaml
@@ -84,6 +84,6 @@ spec:
             periodSeconds: 5
           resources:
             limits:
-              memory: "256Mi"
+              memory: "512Mi"
 
 ---


### PR DESCRIPTION
# Summarry

Since we upgraded to workers on snacpraft we hadden't deployed staging-api.snapcraft.io. It seems that it takes more memory than 256Mi : https://sentry.is.staging.canonical.com/canonical/snapcraftio/issues/1019/?query=is:unresolved

Since snapcraft works well with 512Mi let's try this on staging-api