### PR TITLE
Increase memory brandstores to 512Mi

### DIFF
--- a/services/limenet-snapcraft-io.yaml
+++ b/services/limenet-snapcraft-io.yaml
@@ -40,6 +40,6 @@ spec:
             periodSeconds: 5
           resources:
             limits:
-              memory: "256Mi"
+              memory: "512Mi"
 
 ---

--- a/services/sdrsatcom-snapcraft-io.yaml
+++ b/services/sdrsatcom-snapcraft-io.yaml
@@ -40,6 +40,6 @@ spec:
             periodSeconds: 5
           resources:
             limits:
-              memory: "256Mi"
+              memory: "512Mi"
 
 ---

--- a/services/snapcraft-io.yaml
+++ b/services/snapcraft-io.yaml
@@ -22,7 +22,7 @@ metadata:
   labels:
     useProxy: "true"
 spec:
-  replicas: 9
+  replicas: 5
   template:
     metadata:
       labels:


### PR DESCRIPTION
# Summary

Increase memory from 256Mi to 512Mi since snapcraft uses 8 workers and consume a lot of memory