### PR TITLE
Add sentry configuration to jp

### DIFF
--- a/services/jp-ubuntu-com.yaml
+++ b/services/jp-ubuntu-com.yaml
@@ -32,6 +32,12 @@ spec:
           ports:
             - name: http
               containerPort: 80
+          env:
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: sentry-dsn
+                  key: jp-ubuntu-com
           readinessProbe:
             httpGet:
               path: /


### PR DESCRIPTION
# Summary

Enable sentry on jp

# QA

- Create file sentry.yaml:
```yaml
apiVersion: v1
kind: Secret
metadata:
  name: sentry-dsn
type: Opaque
data:
  jp-ubuntu-com: ASK TOTO
```
- Use microk8s context
- `kubectl apply -f sentry.yaml`
- ` ./qa-deploy --production jp.ubuntu.com --tag latest`
- Make sure pods have the SENTRY_DSN environment variable