### PR TITLE
Read google search api key from snapcraft.io secrets

### DIFF
--- a/services/docs-snapcraft-io.yaml
+++ b/services/docs-snapcraft-io.yaml
@@ -39,6 +39,12 @@ spec:
                 secretKeyRef:
                   name: sentry-dsn
                   key: docs-snapcraft-io
+          env:
+            - name: SEARCH_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: google-api
+                  key: snapcraft-io-search-key
           readinessProbe:
             httpGet:
               path: /


### PR DESCRIPTION
## Done
Updates docs.snapcraft.io to set the google search api key in the containers environment.

## QA
- Create a `google-api` secret in microk8s. Ask me for the key or get it from the api console
```
cat <<EOF > secret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: google-api
type: Opaque
data:
  snapcraft-io-search-key: <base64 google api search key>
EOF
```
- `microk8s.kubectl apply -f secret.yaml`
- `./qa-deploy --production docs-snapcraft-io --tag latest`
- Make sure pod has the right api key set in `SEARCH_API_KEY` (you can see it from the dashboard)

## Issues
Fixes https://github.com/CanonicalLtd/snap-squad/issues/953