### PR TITLE
Update google search secret key

### DIFF
--- a/services/docs-snapcraft-io.yaml
+++ b/services/docs-snapcraft-io.yaml
@@ -44,7 +44,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: google-api
-                  key: snapcraft-io-search-key
+                  key: google-custom-search-key
           readinessProbe:
             httpGet:
               path: /


### PR DESCRIPTION
Renames the secret key that contains the key for the google custom search API.