### PR TITLE
Fix env settings for docs.snapcraft.io

### DIFF
--- a/services/docs-snapcraft-io.yaml
+++ b/services/docs-snapcraft-io.yaml
@@ -39,7 +39,6 @@ spec:
                 secretKeyRef:
                   name: sentry-dsn
                   key: docs-snapcraft-io
-          env:
             - name: SEARCH_API_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Remove duplicate `env` key