### PR TITLE
Use ps5 registry

### DIFF
--- a/cronjobs/snapcraft-monthly-stats-email.yaml
+++ b/cronjobs/snapcraft-monthly-stats-email.yaml
@@ -1,6 +1,6 @@
 name: cronjob-snapcraft-monthly-stats-email
 schedule: "30 12 * * *"
-image: prod-comms.docker-registry.canonical.com/snapcraft-monthly-stats-email
+image: prod-comms.ps5.docker-registry.canonical.com/snapcraft-monthly-stats-email
 
 env:
   - name: SENTRY_DSN

--- a/cronjobs/snapcraft-poller-script.yaml
+++ b/cronjobs/snapcraft-poller-script.yaml
@@ -1,6 +1,6 @@
 name: cronjob-snapcraft-poller-script
 schedule: "0 5 * * *"
-image: prod-comms.docker-registry.canonical.com/snapcraft-poller-script
+image: prod-comms.ps5.docker-registry.canonical.com/snapcraft-poller-script
 
 env:
   - name: SENTRY_DSN

--- a/cronjobs/webteam-ircbot-review-notifier.yaml
+++ b/cronjobs/webteam-ircbot-review-notifier.yaml
@@ -1,6 +1,6 @@
 name: cronjob-webteam-ircbot-review-notifier
 schedule: "0 9 * * 1-5"
-image: prod-comms.docker-registry.canonical.com/task-runner
+image: prod-comms.ps5.docker-registry.canonical.com/task-runner
 
 env:
   - name: HUBOT_RELEASE_NOTIFICATION_SECRET

--- a/cronjobs/webteam-ircbot-support-updater.yaml
+++ b/cronjobs/webteam-ircbot-support-updater.yaml
@@ -1,6 +1,6 @@
 name: cronjob-webteam-ircbot-support-updater
 schedule: "0 8 * * *"
-image: prod-comms.docker-registry.canonical.com/task-runner
+image: prod-comms.ps5.docker-registry.canonical.com/task-runner
 
 env:
   - name: HUBOT_RELEASE_NOTIFICATION_SECRET


### PR DESCRIPTION
Everything is being switched over.

I've updated the relevant docker build jobs and created new docker images within the PS5 registry already:

https://jenkins.canonical.com/webteam/job/task-runner-publish-job/
https://jenkins.canonical.com/webteam/job/snapcraft-monthly-stats-email-publish/
https://jenkins.canonical.com/webteam/job/snapcraft-poller-script-publish/